### PR TITLE
✨ Add interactive TUI with 5 screens, 3 themes, and animations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,11 +7,18 @@
     "": {
       "name": "planner-cli",
       "version": "1.0.0",
+      "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^11.8.1",
+        "chalk": "^5.6.2",
         "commander": "^13.1.0",
         "drizzle-orm": "^0.38.4",
-        "nanoid": "^5.1.2"
+        "ink": "^5.2.1",
+        "ink-select-input": "^6.2.0",
+        "ink-spinner": "^5.0.0",
+        "ink-text-input": "^6.0.0",
+        "nanoid": "^5.1.2",
+        "react": "^18.3.1"
       },
       "bin": {
         "plan": "dist/index.js"
@@ -19,10 +26,28 @@
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.12",
         "@types/node": "^22.13.1",
+        "@types/react": "^18.3.28",
         "drizzle-kit": "^0.30.4",
+        "ink-testing-library": "^4.0.0",
         "tsx": "^4.19.2",
         "typescript": "^5.7.3",
         "vitest": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.1.3.tgz",
+      "integrity": "sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.13.1"
       }
     },
     "node_modules/@drizzle-team/brocli": {
@@ -1319,6 +1344,24 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -1434,6 +1477,45 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1442,6 +1524,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/auto-bind": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/base64-js": {
@@ -1553,6 +1647,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/check-error": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
@@ -1569,6 +1675,89 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
     },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/code-excerpt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
+      "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
+      "license": "MIT",
+      "dependencies": {
+        "convert-to-spaces": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/commander": {
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
@@ -1577,6 +1766,22 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/convert-to-spaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
+      "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1781,6 +1986,12 @@
         }
       }
     },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -1803,12 +2014,34 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+      "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.19.12",
@@ -1862,6 +2095,15 @@
         "esbuild": ">=0.12 <1"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1907,6 +2149,21 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/file-uri-to-path": {
@@ -1957,6 +2214,18 @@
         "node": ">= 18.0.0"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
+      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
@@ -1996,6 +2265,18 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -2007,6 +2288,161 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
+    },
+    "node_modules/ink": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-5.2.1.tgz",
+      "integrity": "sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@alcalzone/ansi-tokenize": "^0.1.3",
+        "ansi-escapes": "^7.0.0",
+        "ansi-styles": "^6.2.1",
+        "auto-bind": "^5.0.1",
+        "chalk": "^5.3.0",
+        "cli-boxes": "^3.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-truncate": "^4.0.0",
+        "code-excerpt": "^4.0.0",
+        "es-toolkit": "^1.22.0",
+        "indent-string": "^5.0.0",
+        "is-in-ci": "^1.0.0",
+        "patch-console": "^2.0.0",
+        "react-reconciler": "^0.29.0",
+        "scheduler": "^0.23.0",
+        "signal-exit": "^3.0.7",
+        "slice-ansi": "^7.1.0",
+        "stack-utils": "^2.0.6",
+        "string-width": "^7.2.0",
+        "type-fest": "^4.27.0",
+        "widest-line": "^5.0.0",
+        "wrap-ansi": "^9.0.0",
+        "ws": "^8.18.0",
+        "yoga-layout": "~3.2.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "react": ">=18.0.0",
+        "react-devtools-core": "^4.19.1"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-devtools-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ink-select-input": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/ink-select-input/-/ink-select-input-6.2.0.tgz",
+      "integrity": "sha512-304fZXxkpYxJ9si5lxRCaX01GNlmPBgOZumXXRnPYbHW/iI31cgQynqk2tRypGLOF1cMIwPUzL2LSm6q4I5rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "figures": "^6.1.0",
+        "to-rotated": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "ink": ">=5.0.0",
+        "react": ">=18.0.0"
+      }
+    },
+    "node_modules/ink-spinner": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ink-spinner/-/ink-spinner-5.0.0.tgz",
+      "integrity": "sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA==",
+      "license": "MIT",
+      "dependencies": {
+        "cli-spinners": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "peerDependencies": {
+        "ink": ">=4.0.0",
+        "react": ">=18.0.0"
+      }
+    },
+    "node_modules/ink-testing-library": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ink-testing-library/-/ink-testing-library-4.0.0.tgz",
+      "integrity": "sha512-yF92kj3pmBvk7oKbSq5vEALO//o7Z9Ck/OaLNlkzXNeYdwfpxMQkSowGTFUCS5MSu9bWfSZMewGpp7bFc66D7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ink-text-input": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ink-text-input/-/ink-text-input-6.0.0.tgz",
+      "integrity": "sha512-Fw64n7Yha5deb1rHY137zHTAbSTNelUKuB5Kkk2HACXEtwIHBCf9OH2tP/LQ9fRYTl1F0dZgbW0zPnZk6FA9Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "type-fest": "^4.18.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "ink": ">=5",
+        "react": ">=18"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-in-ci": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-1.0.0.tgz",
+      "integrity": "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==",
+      "license": "MIT",
+      "bin": {
+        "is-in-ci": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/isexe": {
       "version": "3.1.5",
@@ -2025,6 +2461,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loose-envify/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -2040,6 +2494,15 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/mimic-response": {
@@ -2119,6 +2582,30 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/patch-console": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
+      "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/pathe": {
@@ -2257,6 +2744,34 @@
         "rc": "cli.js"
       }
     },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.2.tgz",
+      "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -2279,6 +2794,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/rollup": {
@@ -2346,6 +2877,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -2376,6 +2916,12 @@
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
     "node_modules/simple-concat": {
@@ -2423,6 +2969,37 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -2454,6 +3031,18 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -2475,6 +3064,38 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/strip-json-comments": {
@@ -2586,6 +3207,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/to-rotated": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-rotated/-/to-rotated-1.0.0.tgz",
+      "integrity": "sha512-KsEID8AfgUy+pxVRLsWp0VzCa69wxzUDZnzGbyIST/bcgcrMvTYoFBX/QORH4YApoD89EDuUovx4BTdpOn319Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tsx": {
@@ -3051,6 +3684,18 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typescript": {
@@ -3717,11 +4362,70 @@
         "node": ">=8"
       }
     },
+    "node_modules/widest-line": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,14 +37,22 @@
   },
   "dependencies": {
     "better-sqlite3": "^11.8.1",
+    "chalk": "^5.6.2",
     "commander": "^13.1.0",
     "drizzle-orm": "^0.38.4",
-    "nanoid": "^5.1.2"
+    "ink": "^5.2.1",
+    "ink-select-input": "^6.2.0",
+    "ink-spinner": "^5.0.0",
+    "ink-text-input": "^6.0.0",
+    "nanoid": "^5.1.2",
+    "react": "^18.3.1"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.12",
     "@types/node": "^22.13.1",
+    "@types/react": "^18.3.28",
     "drizzle-kit": "^0.30.4",
+    "ink-testing-library": "^4.0.0",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
     "vitest": "^3.0.5"

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -6,6 +6,7 @@ import { registerGoalsCommand } from './goals.command.js';
 import { registerTasksCommand } from './tasks.command.js';
 import { registerHabitsCommand } from './habits.command.js';
 import { registerContextCommand } from './context.command.js';
+import { registerTuiCommand } from './tui.command.js';
 
 export function registerCommands(program: Command): void {
   registerInitCommand(program);
@@ -15,4 +16,5 @@ export function registerCommands(program: Command): void {
   registerTasksCommand(program);
   registerHabitsCommand(program);
   registerContextCommand(program);
+  registerTuiCommand(program);
 }

--- a/src/commands/tui.command.ts
+++ b/src/commands/tui.command.ts
@@ -1,0 +1,16 @@
+import type { Command } from 'commander';
+import { ensureInitialized } from '../utils/guard.js';
+import { getContainer } from '../container.js';
+
+export function registerTuiCommand(program: Command): void {
+  program
+    .command('tui')
+    .description('Launch interactive terminal UI')
+    .option('--theme <theme>', 'Color theme: neon, matrix, purple', 'neon')
+    .action(async (opts) => {
+      ensureInitialized();
+      const container = getContainer();
+      const { renderApp } = await import('../tui/app.js');
+      renderApp(container, opts.theme);
+    });
+}

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -1,0 +1,71 @@
+import { useState, useCallback } from 'react';
+import { render, Box } from 'ink';
+import { ThemeContext, themes, themeNames } from './themes/index.js';
+import type { Theme } from './themes/index.js';
+import { ServicesContext, type Container } from './hooks/use-services.js';
+import { useScreen } from './hooks/use-screen.js';
+import { useGlobalKeys } from './hooks/use-global-keys.js';
+import { Layout } from './components/layout.js';
+import { Screen } from './types.js';
+
+interface AppProps {
+  container: Container;
+  initialTheme: string;
+}
+
+function App({ container, initialTheme }: AppProps) {
+  const [themeName, setThemeName] = useState<string>(
+    themeNames.includes(initialTheme) ? initialTheme : 'neon'
+  );
+  const [searchActive, setSearchActive] = useState(false);
+  const theme: Theme = themes[themeName]!;
+
+  const cycleTheme = useCallback(() => {
+    setThemeName(prev => {
+      const idx = themeNames.indexOf(prev);
+      return themeNames[(idx + 1) % themeNames.length]!;
+    });
+  }, []);
+
+  const { screen, goTo, next, prev } = useScreen(Screen.Dashboard);
+
+  const [exiting, setExiting] = useState(false);
+  const onQuit = useCallback(() => setExiting(true), []);
+
+  useGlobalKeys({
+    onQuit,
+    cycleTheme,
+    goToScreen: goTo,
+    nextScreen: next,
+    prevScreen: prev,
+    openSearch: () => setSearchActive(true),
+    searchActive,
+  });
+
+  if (exiting) {
+    return null;
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, themeName, colors: theme.colors, cycleTheme }}>
+      <ServicesContext.Provider value={container}>
+        <Box flexDirection="column">
+          <Layout
+            screen={screen}
+            searchActive={searchActive}
+            onSearchClose={() => setSearchActive(false)}
+          />
+        </Box>
+      </ServicesContext.Provider>
+    </ThemeContext.Provider>
+  );
+}
+
+export function renderApp(container: Container, themeName: string): void {
+  const instance = render(
+    <App container={container} initialTheme={themeName} />
+  );
+  instance.waitUntilExit().then(() => {
+    process.exit(0);
+  });
+}

--- a/src/tui/components/bottom-bar.tsx
+++ b/src/tui/components/bottom-bar.tsx
@@ -1,0 +1,31 @@
+import { Box, Text } from 'ink';
+import { useTheme } from '../hooks/use-theme.js';
+import { SCREEN_ORDER, SCREEN_LABELS, type Screen } from '../types.js';
+
+interface BottomBarProps {
+  screen: Screen;
+}
+
+export function BottomBar({ screen }: BottomBarProps) {
+  const { colors } = useTheme();
+
+  return (
+    <Box justifyContent="space-between" paddingX={1}>
+      <Box gap={1}>
+        {SCREEN_ORDER.map((s, i) => (
+          <Box key={s} gap={0}>
+            <Text color={s === screen ? colors.tabActive : colors.tabInactive} bold={s === screen}>
+              [{i + 1}]{SCREEN_LABELS[s]}
+            </Text>
+            {i < SCREEN_ORDER.length - 1 && <Text color={colors.textSecondary}> </Text>}
+          </Box>
+        ))}
+      </Box>
+      <Box gap={1}>
+        <Text color={colors.textSecondary}>t:theme</Text>
+        <Text color={colors.textSecondary}>/:search</Text>
+        <Text color={colors.textSecondary}>q:quit</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/tui/components/confetti.tsx
+++ b/src/tui/components/confetti.tsx
@@ -1,0 +1,31 @@
+import { Text } from 'ink';
+import { useTheme } from '../hooks/use-theme.js';
+import { useAnimation } from '../hooks/use-animation.js';
+
+const PARTICLES = ['*', '+', '.', '·', '✦', '⋆'];
+
+interface ConfettiProps {
+  active: boolean;
+}
+
+export function Confetti({ active }: ConfettiProps) {
+  const { colors } = useTheme();
+  const frame = useAnimation(150, 6);
+
+  if (!active || frame >= 5) return null;
+
+  const particleColors = [colors.accent1, colors.accent2, colors.success, colors.warning];
+  const line = Array.from({ length: 8 }, () => {
+    const p = PARTICLES[Math.floor(Math.random() * PARTICLES.length)]!;
+    const c = particleColors[Math.floor(Math.random() * particleColors.length)]!;
+    return { char: p, color: c };
+  });
+
+  return (
+    <Text>
+      {line.map((p, i) => (
+        <Text key={i} color={p.color}>{p.char} </Text>
+      ))}
+    </Text>
+  );
+}

--- a/src/tui/components/layout.tsx
+++ b/src/tui/components/layout.tsx
@@ -1,0 +1,75 @@
+import { useState, useCallback } from 'react';
+import { Box, Text, useInput } from 'ink';
+import { TopBar } from './top-bar.js';
+import { BottomBar } from './bottom-bar.js';
+import { SearchOverlay } from './search-overlay.js';
+import { Screen } from '../types.js';
+import { useRefresh } from '../hooks/use-refresh.js';
+import { useTheme } from '../hooks/use-theme.js';
+import { DashboardScreen } from '../screens/dashboard.js';
+import { AreasScreen } from '../screens/areas.js';
+import { GoalsScreen } from '../screens/goals.js';
+import { TasksScreen } from '../screens/tasks.js';
+import { HabitsScreen } from '../screens/habits.js';
+
+interface LayoutProps {
+  screen: Screen;
+  searchActive: boolean;
+  onSearchClose: () => void;
+}
+
+export function Layout({ screen, searchActive, onSearchClose }: LayoutProps) {
+  const { colors } = useTheme();
+  const [refreshKey, refresh] = useRefresh();
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const handleSearchSubmit = useCallback((query: string) => {
+    setSearchQuery(query);
+    onSearchClose();
+  }, [onSearchClose]);
+
+  const handleSearchCancel = useCallback(() => {
+    setSearchQuery('');
+    onSearchClose();
+  }, [onSearchClose]);
+
+  // Allow Escape to clear search when not in search overlay
+  useInput((_input, key) => {
+    if (!searchActive && key.escape && searchQuery) {
+      setSearchQuery('');
+    }
+  });
+
+  const screenProps = { refreshKey, refresh, searchQuery };
+
+  return (
+    <Box flexDirection="column">
+      <TopBar screen={screen} />
+
+      {searchActive && (
+        <SearchOverlay
+          onSubmit={handleSearchSubmit}
+          onCancel={handleSearchCancel}
+        />
+      )}
+
+      {searchQuery && !searchActive && (
+        <Box paddingX={1}>
+          <Text color={colors.warning}>
+            {'🔍 Filtering: "' + searchQuery + '" (Esc to clear)'}
+          </Text>
+        </Box>
+      )}
+
+      <Box flexDirection="column" paddingX={1} minHeight={10}>
+        {screen === Screen.Dashboard && <DashboardScreen refreshKey={refreshKey} searchQuery={searchQuery} />}
+        {screen === Screen.Areas && <AreasScreen {...screenProps} />}
+        {screen === Screen.Goals && <GoalsScreen {...screenProps} />}
+        {screen === Screen.Tasks && <TasksScreen {...screenProps} />}
+        {screen === Screen.Habits && <HabitsScreen {...screenProps} />}
+      </Box>
+
+      <BottomBar screen={screen} />
+    </Box>
+  );
+}

--- a/src/tui/components/list-navigator.tsx
+++ b/src/tui/components/list-navigator.tsx
@@ -1,0 +1,65 @@
+import { useState, useEffect, type ReactNode } from 'react';
+import { Box, Text, useInput } from 'ink';
+import { useTheme } from '../hooks/use-theme.js';
+
+interface ListNavigatorProps<T> {
+  items: T[];
+  renderItem: (item: T, index: number, selected: boolean) => ReactNode;
+  onSelect?: (item: T, index: number) => void;
+  onAction?: (key: string, item: T, index: number) => void;
+  active?: boolean;
+  emptyMessage?: string;
+}
+
+export function ListNavigator<T>({
+  items,
+  renderItem,
+  onSelect,
+  onAction,
+  active = true,
+  emptyMessage = 'No items',
+}: ListNavigatorProps<T>) {
+  const { colors } = useTheme();
+  const [cursor, setCursor] = useState(0);
+
+  useEffect(() => {
+    if (cursor >= items.length && items.length > 0) {
+      setCursor(items.length - 1);
+    }
+  }, [items.length, cursor]);
+
+  useInput((input, key) => {
+    if (!active || items.length === 0) return;
+
+    if (input === 'j' || key.downArrow) {
+      setCursor(c => Math.min(c + 1, items.length - 1));
+    } else if (input === 'k' || key.upArrow) {
+      setCursor(c => Math.max(c - 1, 0));
+    } else if (key.return || input === ' ') {
+      onSelect?.(items[cursor]!, cursor);
+    } else if (onAction) {
+      onAction(input, items[cursor]!, cursor);
+    }
+  });
+
+  if (items.length === 0) {
+    return (
+      <Box paddingX={1}>
+        <Text color={colors.textSecondary} italic>{emptyMessage}</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column">
+      {items.map((item, i) => (
+        <Box key={i}>
+          <Text color={i === cursor ? colors.textAccent : colors.textSecondary}>
+            {i === cursor ? '▸ ' : '  '}
+          </Text>
+          {renderItem(item, i, i === cursor)}
+        </Box>
+      ))}
+    </Box>
+  );
+}

--- a/src/tui/components/panel.tsx
+++ b/src/tui/components/panel.tsx
@@ -1,0 +1,32 @@
+import { Box, Text } from 'ink';
+import { useTheme } from '../hooks/use-theme.js';
+import type { ReactNode } from 'react';
+
+interface PanelProps {
+  title?: string;
+  children: ReactNode;
+  width?: number | string;
+  height?: number | string;
+}
+
+export function Panel({ title, children, width, height }: PanelProps) {
+  const { colors } = useTheme();
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={colors.border}
+      paddingX={1}
+      width={width as number | undefined}
+      height={height as number | undefined}
+    >
+      {title && (
+        <Box marginBottom={0}>
+          <Text color={colors.textAccent} bold>{title}</Text>
+        </Box>
+      )}
+      {children}
+    </Box>
+  );
+}

--- a/src/tui/components/priority-badge.tsx
+++ b/src/tui/components/priority-badge.tsx
@@ -1,0 +1,30 @@
+import { Text } from 'ink';
+import { useTheme } from '../hooks/use-theme.js';
+
+interface PriorityBadgeProps {
+  priority: string;
+}
+
+const PRIORITY_LABELS: Record<string, string> = {
+  low: 'LOW',
+  medium: 'MED',
+  high: 'HIGH',
+  urgent: 'URG',
+};
+
+export function PriorityBadge({ priority }: PriorityBadgeProps) {
+  const { colors } = useTheme();
+
+  const colorMap: Record<string, string> = {
+    low: colors.priorityLow,
+    medium: colors.priorityMed,
+    high: colors.priorityHigh,
+    urgent: colors.priorityUrgent,
+  };
+
+  return (
+    <Text color={colorMap[priority] ?? colors.textSecondary} bold>
+      {PRIORITY_LABELS[priority] ?? priority}
+    </Text>
+  );
+}

--- a/src/tui/components/progress-bar.tsx
+++ b/src/tui/components/progress-bar.tsx
@@ -1,0 +1,45 @@
+import { useState, useEffect } from 'react';
+import { Text } from 'ink';
+import { useTheme } from '../hooks/use-theme.js';
+
+interface ProgressBarProps {
+  value: number; // 0-100
+  width?: number;
+  animated?: boolean;
+}
+
+export function ProgressBar({ value, width = 20, animated = true }: ProgressBarProps) {
+  const { colors } = useTheme();
+  const [displayValue, setDisplayValue] = useState(animated ? 0 : value);
+
+  useEffect(() => {
+    if (!animated) {
+      setDisplayValue(value);
+      return;
+    }
+    setDisplayValue(0);
+    const step = Math.max(1, Math.ceil(value / (width * 2)));
+    const id = setInterval(() => {
+      setDisplayValue(prev => {
+        const next = prev + step;
+        if (next >= value) {
+          clearInterval(id);
+          return value;
+        }
+        return next;
+      });
+    }, 40);
+    return () => clearInterval(id);
+  }, [value, animated, width]);
+
+  const filled = Math.round((displayValue / 100) * width);
+  const empty = width - filled;
+
+  return (
+    <Text>
+      <Text color={colors.progressFill}>{'█'.repeat(filled)}</Text>
+      <Text color={colors.progressTrack}>{'░'.repeat(empty)}</Text>
+      <Text color={colors.textSecondary}> {displayValue}%</Text>
+    </Text>
+  );
+}

--- a/src/tui/components/search-overlay.tsx
+++ b/src/tui/components/search-overlay.tsx
@@ -1,0 +1,32 @@
+import { Box, Text } from 'ink';
+import TextInput from 'ink-text-input';
+import { useState } from 'react';
+import { useTheme } from '../hooks/use-theme.js';
+
+interface SearchOverlayProps {
+  onSubmit: (query: string) => void;
+  onCancel: () => void;
+}
+
+export function SearchOverlay({ onSubmit, onCancel }: SearchOverlayProps) {
+  const { colors } = useTheme();
+  const [query, setQuery] = useState('');
+
+  return (
+    <Box borderStyle="round" borderColor={colors.borderActive} paddingX={1}>
+      <Text color={colors.textAccent} bold>🔍 </Text>
+      <TextInput
+        value={query}
+        onChange={setQuery}
+        onSubmit={(val) => {
+          if (val.trim()) {
+            onSubmit(val.trim());
+          } else {
+            onCancel();
+          }
+        }}
+      />
+      <Text color={colors.textSecondary}> (Esc to cancel)</Text>
+    </Box>
+  );
+}

--- a/src/tui/components/status-badge.tsx
+++ b/src/tui/components/status-badge.tsx
@@ -1,0 +1,32 @@
+import { Text } from 'ink';
+import { useTheme } from '../hooks/use-theme.js';
+
+interface StatusBadgeProps {
+  status: string;
+}
+
+const STATUS_ICONS: Record<string, string> = {
+  todo: '○',
+  in_progress: '◑',
+  done: '●',
+  active: '◑',
+  archived: '◌',
+};
+
+export function StatusBadge({ status }: StatusBadgeProps) {
+  const { colors } = useTheme();
+
+  const colorMap: Record<string, string> = {
+    todo: colors.textSecondary,
+    in_progress: colors.warning,
+    done: colors.success,
+    active: colors.accent1,
+    archived: colors.textSecondary,
+  };
+
+  return (
+    <Text color={colorMap[status] ?? colors.textSecondary}>
+      {STATUS_ICONS[status] ?? '○'} {status.replace('_', ' ')}
+    </Text>
+  );
+}

--- a/src/tui/components/streak-display.tsx
+++ b/src/tui/components/streak-display.tsx
@@ -1,0 +1,31 @@
+import { Text } from 'ink';
+import { useTheme } from '../hooks/use-theme.js';
+import { useAnimation } from '../hooks/use-animation.js';
+
+interface StreakDisplayProps {
+  streak: number;
+  best?: number;
+}
+
+export function StreakDisplay({ streak, best }: StreakDisplayProps) {
+  const { colors } = useTheme();
+  const frame = useAnimation(streak >= 30 ? 300 : 500);
+
+  if (streak === 0) {
+    return <Text color={colors.textSecondary}>no streak</Text>;
+  }
+
+  const pulse = frame % 2 === 0;
+  const fireEmoji = streak >= 30 ? '🔥🔥' : streak >= 7 ? '🔥' : '•';
+  const fireColor = pulse ? colors.streakFire : colors.warning;
+
+  return (
+    <Text>
+      <Text color={fireColor}>{fireEmoji}</Text>
+      <Text color={colors.textPrimary} bold> {streak}d</Text>
+      {best !== undefined && best > streak && (
+        <Text color={colors.textSecondary}> (best: {best})</Text>
+      )}
+    </Text>
+  );
+}

--- a/src/tui/components/top-bar.tsx
+++ b/src/tui/components/top-bar.tsx
@@ -1,0 +1,38 @@
+import { Box, Text } from 'ink';
+import { useTheme } from '../hooks/use-theme.js';
+import { SCREEN_LABELS } from '../types.js';
+import type { Screen } from '../types.js';
+import { useAnimation } from '../hooks/use-animation.js';
+
+interface TopBarProps {
+  screen: Screen;
+}
+
+export function TopBar({ screen }: TopBarProps) {
+  const { colors, themeName } = useTheme();
+  const frame = useAnimation(500);
+  const flash = frame % 2 === 0;
+
+  const dateStr = new Date().toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
+  return (
+    <Box justifyContent="space-between" paddingX={1}>
+      <Box gap={1}>
+        <Text color={colors.accent1} bold>{flash ? '◆' : '◇'}</Text>
+        <Text color={colors.textPrimary} bold>PLANNER</Text>
+        <Text color={colors.textSecondary}>│</Text>
+        <Text color={colors.textAccent} bold>{SCREEN_LABELS[screen]}</Text>
+      </Box>
+      <Box gap={1}>
+        <Text color={colors.textSecondary}>{dateStr}</Text>
+        <Text color={colors.textSecondary}>│</Text>
+        <Text color={colors.accent2}>{themeName}</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/tui/hooks/use-animation.ts
+++ b/src/tui/hooks/use-animation.ts
@@ -1,0 +1,21 @@
+import { useState, useEffect, useRef } from 'react';
+
+export function useAnimation(intervalMs: number, maxFrames?: number): number {
+  const [frame, setFrame] = useState(0);
+  const frameRef = useRef(0);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      frameRef.current += 1;
+      if (maxFrames !== undefined && frameRef.current >= maxFrames) {
+        clearInterval(id);
+        return;
+      }
+      setFrame(frameRef.current);
+    }, intervalMs);
+
+    return () => clearInterval(id);
+  }, [intervalMs, maxFrames]);
+
+  return frame;
+}

--- a/src/tui/hooks/use-global-keys.ts
+++ b/src/tui/hooks/use-global-keys.ts
@@ -1,0 +1,43 @@
+import { useInput } from 'ink';
+import { Screen, SCREEN_KEYS } from '../types.js';
+
+interface UseGlobalKeysOptions {
+  onQuit: () => void;
+  cycleTheme: () => void;
+  goToScreen: (s: Screen) => void;
+  nextScreen: () => void;
+  prevScreen: () => void;
+  openSearch: () => void;
+  searchActive: boolean;
+}
+
+export function useGlobalKeys(opts: UseGlobalKeysOptions): void {
+  useInput((input, key) => {
+    if (opts.searchActive) return;
+
+    if (input === 'q' || key.escape) {
+      opts.onQuit();
+      return;
+    }
+    if (input === 't') {
+      opts.cycleTheme();
+      return;
+    }
+    if (input === '/') {
+      opts.openSearch();
+      return;
+    }
+    if (key.tab && key.shift) {
+      opts.prevScreen();
+      return;
+    }
+    if (key.tab) {
+      opts.nextScreen();
+      return;
+    }
+    const screen = SCREEN_KEYS[input];
+    if (screen) {
+      opts.goToScreen(screen);
+    }
+  });
+}

--- a/src/tui/hooks/use-refresh.ts
+++ b/src/tui/hooks/use-refresh.ts
@@ -1,0 +1,7 @@
+import { useState, useCallback } from 'react';
+
+export function useRefresh(): [number, () => void] {
+  const [key, setKey] = useState(0);
+  const refresh = useCallback(() => setKey(k => k + 1), []);
+  return [key, refresh];
+}

--- a/src/tui/hooks/use-screen.ts
+++ b/src/tui/hooks/use-screen.ts
@@ -1,0 +1,24 @@
+import { useState, useCallback } from 'react';
+import { Screen, SCREEN_ORDER } from '../types.js';
+
+export function useScreen(initial: Screen = Screen.Dashboard) {
+  const [screen, setScreen] = useState<Screen>(initial);
+
+  const goTo = useCallback((s: Screen) => setScreen(s), []);
+
+  const next = useCallback(() => {
+    setScreen(prev => {
+      const idx = SCREEN_ORDER.indexOf(prev);
+      return SCREEN_ORDER[(idx + 1) % SCREEN_ORDER.length]!;
+    });
+  }, []);
+
+  const prev = useCallback(() => {
+    setScreen(prev => {
+      const idx = SCREEN_ORDER.indexOf(prev);
+      return SCREEN_ORDER[(idx - 1 + SCREEN_ORDER.length) % SCREEN_ORDER.length]!;
+    });
+  }, []);
+
+  return { screen, goTo, next, prev };
+}

--- a/src/tui/hooks/use-services.ts
+++ b/src/tui/hooks/use-services.ts
@@ -1,0 +1,12 @@
+import { createContext, useContext } from 'react';
+import type { getContainer } from '../../container.js';
+
+export type Container = ReturnType<typeof getContainer>;
+
+export const ServicesContext = createContext<Container | null>(null);
+
+export function useServices(): Container {
+  const ctx = useContext(ServicesContext);
+  if (!ctx) throw new Error('useServices must be used within ServicesContext.Provider');
+  return ctx;
+}

--- a/src/tui/hooks/use-theme.ts
+++ b/src/tui/hooks/use-theme.ts
@@ -1,0 +1,6 @@
+import { useContext } from 'react';
+import { ThemeContext } from '../themes/index.js';
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/src/tui/screens/areas.tsx
+++ b/src/tui/screens/areas.tsx
@@ -1,0 +1,131 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Box, Text, useInput } from 'ink';
+import { useTheme } from '../hooks/use-theme.js';
+import { useServices } from '../hooks/use-services.js';
+import { Panel } from '../components/panel.js';
+import { ListNavigator } from '../components/list-navigator.js';
+import type { AreaWithStats, AreaDetail } from '../../services/area.service.js';
+
+interface AreasScreenProps {
+  refreshKey: number;
+  refresh: () => void;
+  searchQuery: string;
+}
+
+export function AreasScreen({ refreshKey, refresh, searchQuery }: AreasScreenProps) {
+  const { colors } = useTheme();
+  const { areaService } = useServices();
+
+  const getAreas = (): AreaWithStats[] => {
+    try { return areaService.list(); } catch { return []; }
+  };
+  const [areas, setAreas] = useState<AreaWithStats[]>(getAreas);
+  const [detail, setDetail] = useState<AreaDetail | null>(null);
+
+  useEffect(() => {
+    setAreas(getAreas());
+  }, [refreshKey]);
+
+  const filtered = areas.filter(a =>
+    !searchQuery || a.name.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  const handleSelect = useCallback((area: AreaWithStats) => {
+    try {
+      setDetail(areaService.show(area.id));
+    } catch {
+      // ignore
+    }
+  }, [areaService]);
+
+  useInput((input, key) => {
+    if (detail && (key.backspace || key.delete || key.escape || input === 'h')) {
+      setDetail(null);
+    }
+  });
+
+  if (detail) {
+    return (
+      <Box flexDirection="column" gap={1}>
+        <Panel title={`📂 ${detail.name}`}>
+          {detail.description && (
+            <Text color={colors.textPrimary}>{detail.description}</Text>
+          )}
+        </Panel>
+
+        {detail.goals.length > 0 && (
+          <Panel title="🎯 Goals">
+            {detail.goals.map(g => (
+              <Box key={g.id} gap={1}>
+                <Text color={g.status === 'done' ? colors.success : colors.textPrimary}>
+                  {g.status === 'done' ? '●' : g.status === 'active' ? '◑' : '◌'}
+                </Text>
+                <Text color={colors.textPrimary}>{g.title}</Text>
+                <Text color={colors.textSecondary}>{g.progress}%</Text>
+              </Box>
+            ))}
+          </Panel>
+        )}
+
+        {detail.tasks.length > 0 && (
+          <Panel title="📋 Tasks">
+            {detail.tasks.map(t => (
+              <Box key={t.id} gap={1}>
+                <Text color={colors.textSecondary}>
+                  {t.status === 'done' ? '●' : t.status === 'in_progress' ? '◑' : '○'}
+                </Text>
+                <Text
+                  color={colors.textPrimary}
+                  strikethrough={t.status === 'done'}
+                >
+                  {t.title}
+                </Text>
+              </Box>
+            ))}
+          </Panel>
+        )}
+
+        {detail.habits.length > 0 && (
+          <Panel title="🔄 Habits">
+            {detail.habits.map(h => (
+              <Box key={h.id} gap={1}>
+                <Text color={colors.textPrimary}>{h.title}</Text>
+                <Text color={colors.textSecondary}>streak: {h.currentStreak}d</Text>
+              </Box>
+            ))}
+          </Panel>
+        )}
+
+        <Text color={colors.textSecondary} italic>Backspace: back to list</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Panel title="📂 Areas">
+        <ListNavigator
+          items={filtered}
+          emptyMessage="No areas found"
+          onSelect={handleSelect}
+          renderItem={(area, _i, selected) => (
+            <Box gap={1}>
+              <Text
+                color={selected ? colors.textAccent : colors.textPrimary}
+                bold={selected}
+              >
+                {area.name}
+              </Text>
+              <Text color={colors.textSecondary}>
+                {area.goalCount}g {area.taskCount}t {area.habitCount}h
+              </Text>
+            </Box>
+          )}
+        />
+        <Box marginTop={1}>
+          <Text color={colors.textSecondary} italic>Enter: view details</Text>
+        </Box>
+      </Panel>
+    </Box>
+  );
+}

--- a/src/tui/screens/dashboard.tsx
+++ b/src/tui/screens/dashboard.tsx
@@ -1,0 +1,126 @@
+import { useState, useEffect } from 'react';
+import { Box, Text } from 'ink';
+import { useTheme } from '../hooks/use-theme.js';
+import { useServices } from '../hooks/use-services.js';
+import { Panel } from '../components/panel.js';
+import { StreakDisplay } from '../components/streak-display.js';
+import { PriorityBadge } from '../components/priority-badge.js';
+import type { StatusData } from '../../services/status.service.js';
+
+interface DashboardProps {
+  refreshKey: number;
+  searchQuery: string;
+}
+
+export function DashboardScreen({ refreshKey, searchQuery }: DashboardProps) {
+  const { colors } = useTheme();
+  const { statusService, habitService } = useServices();
+  const getData = (): StatusData | null => {
+    try { return statusService.getStatus(); } catch { return null; }
+  };
+  const [data, setData] = useState<StatusData | null>(getData);
+
+  useEffect(() => {
+    setData(getData());
+  }, [refreshKey]);
+
+  if (!data) {
+    return (
+      <Box paddingX={1}>
+        <Text color={colors.textSecondary}>No data. Run `plan init` first.</Text>
+      </Box>
+    );
+  }
+
+  const streaks = habitService.streaks();
+  const topStreaks = streaks
+    .filter(s => s.currentStreak > 0)
+    .sort((a, b) => b.currentStreak - a.currentStreak)
+    .slice(0, 5);
+
+  const matchesSearch = (text: string) =>
+    !searchQuery || text.toLowerCase().includes(searchQuery.toLowerCase());
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Box gap={1}>
+        <Panel title="📊 Summary">
+          <Text color={colors.textPrimary}>
+            <Text color={colors.textAccent} bold>{data.dateFormatted}</Text>
+          </Text>
+          <Text color={colors.textPrimary}>
+            Tasks due: <Text color={data.summary.tasksDue > 0 ? colors.warning : colors.success} bold>{data.summary.tasksDue}</Text>
+          </Text>
+          <Text color={colors.textPrimary}>
+            Overdue: <Text color={data.summary.tasksOverdue > 0 ? colors.error : colors.success} bold>{data.summary.tasksOverdue}</Text>
+          </Text>
+          <Text color={colors.textPrimary}>
+            Habits: <Text color={colors.success} bold>{data.summary.habitsDone}</Text>
+            <Text color={colors.textSecondary}>/{data.summary.habitsDue}</Text>
+          </Text>
+        </Panel>
+
+        {topStreaks.length > 0 && (
+          <Panel title="🔥 Active Streaks">
+            {topStreaks.map(s => (
+              <Box key={s.id} gap={1}>
+                <Text color={colors.textPrimary}>{s.title}</Text>
+                <StreakDisplay streak={s.currentStreak} best={s.bestStreak} />
+              </Box>
+            ))}
+          </Panel>
+        )}
+      </Box>
+
+      <Box gap={1}>
+        <Panel title="📋 Tasks Due Today">
+          {data.tasksDueToday.length === 0 ? (
+            <Text color={colors.textSecondary} italic>No tasks due today</Text>
+          ) : (
+            data.tasksDueToday.filter(t => matchesSearch(t.title)).map(task => (
+              <Box key={task.id} gap={1}>
+                <PriorityBadge priority={task.priority} />
+                <Text color={colors.textPrimary}>{task.title}</Text>
+              </Box>
+            ))
+          )}
+        </Panel>
+
+        <Panel title="⚠️  Overdue">
+          {data.tasksOverdue.length === 0 ? (
+            <Text color={colors.success} italic>All clear!</Text>
+          ) : (
+            data.tasksOverdue.filter(t => matchesSearch(t.title)).map(task => (
+              <Box key={task.id} gap={1}>
+                <Text color={colors.error} bold>{task.daysOverdue}d</Text>
+                <Text color={colors.textPrimary}>{task.title}</Text>
+              </Box>
+            ))
+          )}
+        </Panel>
+      </Box>
+
+      <Panel title="✅ Today's Habits">
+        {data.habitsDueToday.length === 0 ? (
+          <Text color={colors.textSecondary} italic>No habits due today</Text>
+        ) : (
+          <Box gap={2}>
+            {data.habitsDueToday.filter(h => matchesSearch(h.title)).map(habit => (
+              <Box key={habit.id} gap={1}>
+                <Text color={habit.done ? colors.success : colors.textSecondary}>
+                  {habit.done ? '●' : '○'}
+                </Text>
+                <Text
+                  color={habit.done ? colors.success : colors.textPrimary}
+                  strikethrough={habit.done}
+                >
+                  {habit.title}
+                </Text>
+              </Box>
+            ))}
+          </Box>
+        )}
+      </Panel>
+    </Box>
+  );
+}

--- a/src/tui/screens/goals.tsx
+++ b/src/tui/screens/goals.tsx
@@ -1,0 +1,144 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Box, Text, useInput } from 'ink';
+import { useTheme } from '../hooks/use-theme.js';
+import { useServices } from '../hooks/use-services.js';
+import { Panel } from '../components/panel.js';
+import { PriorityBadge } from '../components/priority-badge.js';
+import { ProgressBar } from '../components/progress-bar.js';
+import { ListNavigator } from '../components/list-navigator.js';
+import type { Goal } from '../../db/schema.js';
+import type { GoalDetail } from '../../services/goal.service.js';
+
+interface GoalsScreenProps {
+  refreshKey: number;
+  refresh: () => void;
+  searchQuery: string;
+}
+
+export function GoalsScreen({ refreshKey, refresh, searchQuery }: GoalsScreenProps) {
+  const { colors } = useTheme();
+  const { goalService } = useServices();
+
+  const getGoals = (): Goal[] => {
+    try { return goalService.list({ status: 'active' }); } catch { return []; }
+  };
+  const [goals, setGoals] = useState<Goal[]>(getGoals);
+  const [detail, setDetail] = useState<GoalDetail | null>(null);
+
+  useEffect(() => {
+    setGoals(getGoals());
+  }, [refreshKey]);
+
+  const filtered = goals.filter(g =>
+    !searchQuery || g.title.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  const handleSelect = useCallback((goal: Goal) => {
+    try {
+      setDetail(goalService.show(goal.id));
+    } catch {
+      // ignore
+    }
+  }, [goalService]);
+
+  useInput((input, key) => {
+    if (detail && (key.backspace || key.delete || key.escape || input === 'h')) {
+      setDetail(null);
+    }
+  });
+
+  if (detail) {
+    return (
+      <Box flexDirection="column" gap={1}>
+        <Panel title={`🎯 ${detail.title}`}>
+          <Box gap={1}>
+            <PriorityBadge priority={detail.priority} />
+            <Text color={colors.textSecondary}>
+              {detail.status} {detail.targetDate ? `· target: ${detail.targetDate}` : ''}
+            </Text>
+          </Box>
+          {detail.description && (
+            <Text color={colors.textPrimary}>{detail.description}</Text>
+          )}
+          <Box marginTop={1}>
+            <ProgressBar value={detail.progress} width={30} />
+          </Box>
+        </Panel>
+
+        {detail.milestones.length > 0 && (
+          <Panel title="📌 Milestones">
+            {detail.milestones.map(ms => (
+              <Box key={ms.id} gap={1}>
+                <Text color={ms.done ? colors.success : colors.textSecondary}>
+                  {ms.done ? '●' : '○'}
+                </Text>
+                <Text
+                  color={ms.done ? colors.success : colors.textPrimary}
+                  strikethrough={ms.done}
+                >
+                  {ms.title}
+                </Text>
+              </Box>
+            ))}
+          </Panel>
+        )}
+
+        {detail.tasks.length > 0 && (
+          <Panel title="📋 Linked Tasks">
+            {detail.tasks.map(t => (
+              <Box key={t.id} gap={1}>
+                <Text color={colors.textSecondary}>
+                  {t.status === 'done' ? '●' : t.status === 'in_progress' ? '◑' : '○'}
+                </Text>
+                <Text color={colors.textPrimary}>{t.title}</Text>
+              </Box>
+            ))}
+          </Panel>
+        )}
+
+        {detail.habits.length > 0 && (
+          <Panel title="🔄 Linked Habits">
+            {detail.habits.map(h => (
+              <Box key={h.id} gap={1}>
+                <Text color={colors.textPrimary}>{h.title}</Text>
+                <Text color={colors.textSecondary}>streak: {h.currentStreak}d</Text>
+              </Box>
+            ))}
+          </Panel>
+        )}
+
+        <Text color={colors.textSecondary} italic>Backspace: back to list</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Panel title="🎯 Goals">
+        <ListNavigator
+          items={filtered}
+          emptyMessage="No active goals"
+          onSelect={handleSelect}
+          renderItem={(goal, _i, selected) => (
+            <Box gap={1}>
+              <PriorityBadge priority={goal.priority} />
+              <Text
+                color={selected ? colors.textAccent : colors.textPrimary}
+                bold={selected}
+              >
+                {goal.title}
+              </Text>
+              <ProgressBar value={goal.progress} width={15} animated={false} />
+              {goal.targetDate && (
+                <Text color={colors.textSecondary}>[{goal.targetDate}]</Text>
+              )}
+            </Box>
+          )}
+        />
+        <Box marginTop={1}>
+          <Text color={colors.textSecondary} italic>Enter: view details</Text>
+        </Box>
+      </Panel>
+    </Box>
+  );
+}

--- a/src/tui/screens/habits.tsx
+++ b/src/tui/screens/habits.tsx
@@ -1,0 +1,104 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Box, Text } from 'ink';
+import { useTheme } from '../hooks/use-theme.js';
+import { useServices } from '../hooks/use-services.js';
+import { Panel } from '../components/panel.js';
+import { StreakDisplay } from '../components/streak-display.js';
+import { ListNavigator } from '../components/list-navigator.js';
+import { Confetti } from '../components/confetti.js';
+import type { Habit } from '../../db/schema.js';
+
+interface HabitsScreenProps {
+  refreshKey: number;
+  refresh: () => void;
+  searchQuery: string;
+}
+
+export function HabitsScreen({ refreshKey, refresh, searchQuery }: HabitsScreenProps) {
+  const { colors } = useTheme();
+  const { habitService } = useServices();
+
+  const getHabits = (): Array<Habit & { done: boolean }> => {
+    try { return habitService.getHabitsDueToday(); } catch { return []; }
+  };
+  const [habits, setHabits] = useState<Array<Habit & { done: boolean }>>(getHabits);
+  const [message, setMessage] = useState('');
+  const [showConfetti, setShowConfetti] = useState(false);
+
+  useEffect(() => {
+    setHabits(getHabits());
+  }, [refreshKey]);
+
+  const filtered = habits.filter(h =>
+    !searchQuery || h.title.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  const handleToggle = useCallback((habit: Habit & { done: boolean }) => {
+    try {
+      if (habit.done) {
+        habitService.uncheck(habit.id);
+      } else {
+        habitService.check(habit.id);
+        // Show confetti if this was the last unchecked habit
+        const remaining = habits.filter(h => !h.done && h.id !== habit.id);
+        if (remaining.length === 0) {
+          setShowConfetti(true);
+          setTimeout(() => setShowConfetti(false), 1000);
+        }
+      }
+      setMessage('');
+      refresh();
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : 'Error');
+    }
+  }, [habitService, habits, refresh]);
+
+  const streaks = habitService.streaks();
+  const doneCount = habits.filter(h => h.done).length;
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Panel title={`✅ Today's Habits (${doneCount}/${habits.length})`}>
+        {showConfetti && <Confetti active={showConfetti} />}
+        <ListNavigator
+          items={filtered}
+          emptyMessage="No habits due today"
+          onSelect={handleToggle}
+          renderItem={(habit, _i, selected) => (
+            <Box gap={1} width="100%">
+              <Text color={habit.done ? colors.success : colors.textSecondary}>
+                {habit.done ? '[✓]' : '[ ]'}
+              </Text>
+              <Text
+                color={selected ? colors.textAccent : colors.textPrimary}
+                strikethrough={habit.done}
+                bold={selected}
+              >
+                {habit.title}
+              </Text>
+              <Text color={colors.textSecondary}>{habit.frequency}</Text>
+            </Box>
+          )}
+        />
+        {message && <Text color={colors.error}>{message}</Text>}
+        <Box marginTop={1}>
+          <Text color={colors.textSecondary} italic>Space/Enter: toggle check</Text>
+        </Box>
+      </Panel>
+
+      {streaks.length > 0 && (
+        <Panel title="🔥 Streaks">
+          {streaks
+            .sort((a, b) => b.currentStreak - a.currentStreak)
+            .slice(0, 8)
+            .map(s => (
+              <Box key={s.id} gap={1} justifyContent="space-between">
+                <Text color={colors.textPrimary}>{s.title}</Text>
+                <StreakDisplay streak={s.currentStreak} best={s.bestStreak} />
+              </Box>
+            ))}
+        </Panel>
+      )}
+    </Box>
+  );
+}

--- a/src/tui/screens/tasks.tsx
+++ b/src/tui/screens/tasks.tsx
@@ -1,0 +1,119 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Box, Text } from 'ink';
+import { useTheme } from '../hooks/use-theme.js';
+import { useServices } from '../hooks/use-services.js';
+import { Panel } from '../components/panel.js';
+import { PriorityBadge } from '../components/priority-badge.js';
+import { StatusBadge } from '../components/status-badge.js';
+import { ListNavigator } from '../components/list-navigator.js';
+import { useAnimation } from '../hooks/use-animation.js';
+import type { Task } from '../../db/schema.js';
+
+interface TasksScreenProps {
+  refreshKey: number;
+  refresh: () => void;
+  searchQuery: string;
+}
+
+type Filter = 'all' | 'todo' | 'in_progress' | 'done';
+
+function OverdueIndicator({ dueDate }: { dueDate: string | null }) {
+  const { colors } = useTheme();
+  const frame = useAnimation(800);
+
+  if (!dueDate) return null;
+  const now = new Date();
+  const due = new Date(dueDate + 'T00:00:00');
+  if (due >= now) return null;
+
+  const days = Math.ceil((now.getTime() - due.getTime()) / (1000 * 60 * 60 * 24));
+  const pulse = frame % 2 === 0;
+
+  return (
+    <Text color={pulse ? colors.error : colors.warning} bold>
+      {days}d overdue
+    </Text>
+  );
+}
+
+export function TasksScreen({ refreshKey, refresh, searchQuery }: TasksScreenProps) {
+  const { colors } = useTheme();
+  const { taskService } = useServices();
+
+  const [filter, setFilter] = useState<Filter>('all');
+  const getTasks = (): Task[] => {
+    try {
+      const filters = filter === 'all' ? undefined : { status: filter };
+      return taskService.list(filters);
+    } catch { return []; }
+  };
+  const [tasks, setTasks] = useState<Task[]>(getTasks);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    setTasks(getTasks());
+  }, [refreshKey, filter]);
+
+  const filtered = tasks.filter(t =>
+    !searchQuery || t.title.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  const handleAction = useCallback((key: string, task: Task) => {
+    try {
+      if (key === 'd' && task.status !== 'done') {
+        taskService.markDone(task.id);
+        setMessage(`Marked "${task.title}" done`);
+        refresh();
+      } else if (key === 's' && task.status === 'todo') {
+        taskService.start(task.id);
+        setMessage(`Started "${task.title}"`);
+        refresh();
+      } else if (key === 'f') {
+        const filters: Filter[] = ['all', 'todo', 'in_progress', 'done'];
+        setFilter(prev => {
+          const idx = filters.indexOf(prev);
+          return filters[(idx + 1) % filters.length]!;
+        });
+      }
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : 'Error');
+    }
+  }, [taskService, refresh]);
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Panel title={`📋 Tasks [filter: ${filter}]`}>
+        <ListNavigator
+          items={filtered}
+          emptyMessage="No tasks found"
+          onAction={handleAction}
+          renderItem={(task, _i, selected) => (
+            <Box gap={1}>
+              <StatusBadge status={task.status} />
+              <PriorityBadge priority={task.priority} />
+              <Text
+                color={selected ? colors.textAccent : colors.textPrimary}
+                bold={selected}
+                strikethrough={task.status === 'done'}
+              >
+                {task.title}
+              </Text>
+              {task.dueDate && (
+                <Text color={colors.textSecondary}>[{task.dueDate}]</Text>
+              )}
+              <OverdueIndicator dueDate={task.dueDate} />
+            </Box>
+          )}
+        />
+        {message && (
+          <Box marginTop={1}>
+            <Text color={colors.success}>{message}</Text>
+          </Box>
+        )}
+        <Box marginTop={1} gap={2}>
+          <Text color={colors.textSecondary} italic>d:done s:start f:filter</Text>
+        </Box>
+      </Panel>
+    </Box>
+  );
+}

--- a/src/tui/themes/index.ts
+++ b/src/tui/themes/index.ts
@@ -1,0 +1,29 @@
+import { createContext } from 'react';
+import type { Theme, ColorTokens } from './tokens.js';
+import { neonTheme } from './neon.js';
+import { matrixTheme } from './matrix.js';
+import { purpleTheme } from './purple.js';
+
+export type { Theme, ColorTokens };
+
+export const themes: Record<string, Theme> = {
+  neon: neonTheme,
+  matrix: matrixTheme,
+  purple: purpleTheme,
+};
+
+export const themeNames = Object.keys(themes) as string[];
+
+export interface ThemeContextValue {
+  theme: Theme;
+  themeName: string;
+  colors: ColorTokens;
+  cycleTheme: () => void;
+}
+
+export const ThemeContext = createContext<ThemeContextValue>({
+  theme: neonTheme,
+  themeName: 'neon',
+  colors: neonTheme.colors,
+  cycleTheme: () => {},
+});

--- a/src/tui/themes/matrix.ts
+++ b/src/tui/themes/matrix.ts
@@ -1,0 +1,29 @@
+import type { Theme } from './tokens.js';
+
+export const matrixTheme: Theme = {
+  name: 'matrix',
+  colors: {
+    bg: '#000000',
+    bgPanel: '#001100',
+    bgHighlight: '#002200',
+    textPrimary: '#00ff00',
+    textSecondary: '#006600',
+    textAccent: '#00ff66',
+    success: '#00ff00',
+    warning: '#ccff00',
+    error: '#ff0000',
+    priorityLow: '#004400',
+    priorityMed: '#00aa00',
+    priorityHigh: '#ccff00',
+    priorityUrgent: '#ff0000',
+    accent1: '#00ff66',
+    accent2: '#33ff99',
+    streakFire: '#ccff00',
+    progressFill: '#00ff00',
+    progressTrack: '#003300',
+    border: '#004400',
+    borderActive: '#00ff66',
+    tabActive: '#00ff66',
+    tabInactive: '#003300',
+  },
+};

--- a/src/tui/themes/neon.ts
+++ b/src/tui/themes/neon.ts
@@ -1,0 +1,29 @@
+import type { Theme } from './tokens.js';
+
+export const neonTheme: Theme = {
+  name: 'neon',
+  colors: {
+    bg: '#0a0a1a',
+    bgPanel: '#111128',
+    bgHighlight: '#1a1a3e',
+    textPrimary: '#e0e0ff',
+    textSecondary: '#7777aa',
+    textAccent: '#00d4ff',
+    success: '#00ff88',
+    warning: '#ffaa00',
+    error: '#ff3366',
+    priorityLow: '#4488cc',
+    priorityMed: '#00d4ff',
+    priorityHigh: '#ff6600',
+    priorityUrgent: '#ff3366',
+    accent1: '#00d4ff',
+    accent2: '#ff44aa',
+    streakFire: '#ff6600',
+    progressFill: '#00d4ff',
+    progressTrack: '#222244',
+    border: '#333366',
+    borderActive: '#00d4ff',
+    tabActive: '#00d4ff',
+    tabInactive: '#444477',
+  },
+};

--- a/src/tui/themes/purple.ts
+++ b/src/tui/themes/purple.ts
@@ -1,0 +1,29 @@
+import type { Theme } from './tokens.js';
+
+export const purpleTheme: Theme = {
+  name: 'purple',
+  colors: {
+    bg: '#1a0a2e',
+    bgPanel: '#220e3d',
+    bgHighlight: '#2d1550',
+    textPrimary: '#e8d5ff',
+    textSecondary: '#9966cc',
+    textAccent: '#cc88ff',
+    success: '#66ff99',
+    warning: '#ffcc44',
+    error: '#ff5555',
+    priorityLow: '#7744aa',
+    priorityMed: '#9966cc',
+    priorityHigh: '#ff8844',
+    priorityUrgent: '#ff5555',
+    accent1: '#cc88ff',
+    accent2: '#ff88cc',
+    streakFire: '#ff8844',
+    progressFill: '#cc88ff',
+    progressTrack: '#2d1550',
+    border: '#442266',
+    borderActive: '#cc88ff',
+    tabActive: '#cc88ff',
+    tabInactive: '#442266',
+  },
+};

--- a/src/tui/themes/tokens.ts
+++ b/src/tui/themes/tokens.ts
@@ -1,0 +1,29 @@
+export interface ColorTokens {
+  bg: string;
+  bgPanel: string;
+  bgHighlight: string;
+  textPrimary: string;
+  textSecondary: string;
+  textAccent: string;
+  success: string;
+  warning: string;
+  error: string;
+  priorityLow: string;
+  priorityMed: string;
+  priorityHigh: string;
+  priorityUrgent: string;
+  accent1: string;
+  accent2: string;
+  streakFire: string;
+  progressFill: string;
+  progressTrack: string;
+  border: string;
+  borderActive: string;
+  tabActive: string;
+  tabInactive: string;
+}
+
+export interface Theme {
+  name: string;
+  colors: ColorTokens;
+}

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -1,0 +1,31 @@
+export enum Screen {
+  Dashboard = 'dashboard',
+  Areas = 'areas',
+  Goals = 'goals',
+  Tasks = 'tasks',
+  Habits = 'habits',
+}
+
+export const SCREEN_ORDER: Screen[] = [
+  Screen.Dashboard,
+  Screen.Areas,
+  Screen.Goals,
+  Screen.Tasks,
+  Screen.Habits,
+];
+
+export const SCREEN_KEYS: Record<string, Screen> = {
+  '1': Screen.Dashboard,
+  '2': Screen.Areas,
+  '3': Screen.Goals,
+  '4': Screen.Tasks,
+  '5': Screen.Habits,
+};
+
+export const SCREEN_LABELS: Record<Screen, string> = {
+  [Screen.Dashboard]: 'Dashboard',
+  [Screen.Areas]: 'Areas',
+  [Screen.Goals]: 'Goals',
+  [Screen.Tasks]: 'Tasks',
+  [Screen.Habits]: 'Habits',
+};

--- a/tests/e2e/tui.test.ts
+++ b/tests/e2e/tui.test.ts
@@ -1,0 +1,27 @@
+import { execSync, spawn } from 'child_process';
+import { join } from 'path';
+import { setupTestDir, cleanupTestDir, runCli } from './helpers/cli.js';
+
+describe('plan tui', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = setupTestDir();
+    runCli('init', testDir);
+  });
+
+  afterEach(() => {
+    cleanupTestDir(testDir);
+  });
+
+  it('registers the tui command in help output', () => {
+    const { stdout } = runCli('--help', testDir);
+    expect(stdout).toContain('tui');
+  });
+
+  it('shows tui command help', () => {
+    const { stdout } = runCli('tui --help', testDir);
+    expect(stdout).toContain('interactive terminal UI');
+    expect(stdout).toContain('--theme');
+  });
+});

--- a/tests/integration/tui-screens.test.tsx
+++ b/tests/integration/tui-screens.test.tsx
@@ -1,0 +1,175 @@
+import { render } from 'ink-testing-library';
+import { ThemeContext, themes } from '../../src/tui/themes/index.js';
+import { ServicesContext } from '../../src/tui/hooks/use-services.js';
+import { createTestContainer } from '../../src/container.js';
+import { createTestDb } from './helpers/db.js';
+import { DashboardScreen } from '../../src/tui/screens/dashboard.js';
+import { AreasScreen } from '../../src/tui/screens/areas.js';
+import { GoalsScreen } from '../../src/tui/screens/goals.js';
+import { TasksScreen } from '../../src/tui/screens/tasks.js';
+import { HabitsScreen } from '../../src/tui/screens/habits.js';
+import { TopBar } from '../../src/tui/components/top-bar.js';
+import { BottomBar } from '../../src/tui/components/bottom-bar.js';
+import { Screen } from '../../src/tui/types.js';
+import React from 'react';
+
+const neon = themes['neon']!;
+const themeValue = {
+  theme: neon,
+  themeName: 'neon',
+  colors: neon.colors,
+  cycleTheme: () => {},
+};
+
+function createWrapper() {
+  const db = createTestDb();
+  const container = createTestContainer(db);
+  // Seed some data
+  container.areaService.add('Work', 'Work area');
+  container.areaService.add('Health');
+  const goal = container.goalService.add('Learn TypeScript', { priority: 'high' });
+  container.taskService.add('Write tests', { priority: 'medium' });
+  container.habitService.add('Exercise', { frequency: 'daily' });
+
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <ThemeContext.Provider value={themeValue}>
+        <ServicesContext.Provider value={container}>
+          {children}
+        </ServicesContext.Provider>
+      </ThemeContext.Provider>
+    );
+  }
+
+  return { Wrapper, container };
+}
+
+describe('TUI Screens', () => {
+  describe('TopBar', () => {
+    it('renders screen name and planner title', () => {
+      const { Wrapper } = createWrapper();
+      const { lastFrame } = render(
+        <Wrapper>
+          <TopBar screen={Screen.Dashboard} />
+        </Wrapper>
+      );
+      const frame = lastFrame()!;
+      expect(frame).toContain('PLANNER');
+      expect(frame).toContain('Dashboard');
+      expect(frame).toContain('neon');
+    });
+  });
+
+  describe('BottomBar', () => {
+    it('renders tab strip with all screens', () => {
+      const { Wrapper } = createWrapper();
+      const { lastFrame } = render(
+        <Wrapper>
+          <BottomBar screen={Screen.Dashboard} />
+        </Wrapper>
+      );
+      const frame = lastFrame()!;
+      expect(frame).toContain('[1]Dashboard');
+      expect(frame).toContain('[2]Areas');
+      expect(frame).toContain('[3]Goals');
+      expect(frame).toContain('[4]Tasks');
+      expect(frame).toContain('[5]Habits');
+      expect(frame).toContain('q:quit');
+    });
+  });
+
+  describe('DashboardScreen', () => {
+    it('renders summary with data', () => {
+      const { Wrapper } = createWrapper();
+      const { lastFrame } = render(
+        <Wrapper>
+          <DashboardScreen refreshKey={0} searchQuery="" />
+        </Wrapper>
+      );
+      const frame = lastFrame()!;
+      expect(frame).toContain('Summary');
+      expect(frame).toContain('Tasks due');
+      expect(frame).toContain('Habits');
+    });
+
+    it('shows habits due today', () => {
+      const { Wrapper } = createWrapper();
+      const { lastFrame } = render(
+        <Wrapper>
+          <DashboardScreen refreshKey={0} searchQuery="" />
+        </Wrapper>
+      );
+      const frame = lastFrame()!;
+      expect(frame).toContain('Exercise');
+    });
+  });
+
+  describe('AreasScreen', () => {
+    it('renders area list', () => {
+      const { Wrapper } = createWrapper();
+      const { lastFrame } = render(
+        <Wrapper>
+          <AreasScreen refreshKey={0} refresh={() => {}} searchQuery="" />
+        </Wrapper>
+      );
+      const frame = lastFrame()!;
+      expect(frame).toContain('Areas');
+      expect(frame).toContain('Work');
+      expect(frame).toContain('Health');
+    });
+
+    it('filters by search query', () => {
+      const { Wrapper } = createWrapper();
+      const { lastFrame } = render(
+        <Wrapper>
+          <AreasScreen refreshKey={0} refresh={() => {}} searchQuery="work" />
+        </Wrapper>
+      );
+      const frame = lastFrame()!;
+      expect(frame).toContain('Work');
+      expect(frame).not.toContain('Health');
+    });
+  });
+
+  describe('GoalsScreen', () => {
+    it('renders goal list', () => {
+      const { Wrapper } = createWrapper();
+      const { lastFrame } = render(
+        <Wrapper>
+          <GoalsScreen refreshKey={0} refresh={() => {}} searchQuery="" />
+        </Wrapper>
+      );
+      const frame = lastFrame()!;
+      expect(frame).toContain('Goals');
+      expect(frame).toContain('Learn TypeScript');
+    });
+  });
+
+  describe('TasksScreen', () => {
+    it('renders task list', () => {
+      const { Wrapper } = createWrapper();
+      const { lastFrame } = render(
+        <Wrapper>
+          <TasksScreen refreshKey={0} refresh={() => {}} searchQuery="" />
+        </Wrapper>
+      );
+      const frame = lastFrame()!;
+      expect(frame).toContain('Tasks');
+      expect(frame).toContain('Write tests');
+    });
+  });
+
+  describe('HabitsScreen', () => {
+    it('renders habits due today', () => {
+      const { Wrapper } = createWrapper();
+      const { lastFrame } = render(
+        <Wrapper>
+          <HabitsScreen refreshKey={0} refresh={() => {}} searchQuery="" />
+        </Wrapper>
+      );
+      const frame = lastFrame()!;
+      expect(frame).toContain('Habits');
+      expect(frame).toContain('Exercise');
+    });
+  });
+});

--- a/tests/unit/tui-types.test.ts
+++ b/tests/unit/tui-types.test.ts
@@ -1,0 +1,77 @@
+import { Screen, SCREEN_ORDER, SCREEN_KEYS, SCREEN_LABELS } from '../../src/tui/types.js';
+import { themes, themeNames } from '../../src/tui/themes/index.js';
+import type { ColorTokens } from '../../src/tui/themes/tokens.js';
+
+describe('TUI types', () => {
+  it('has 5 screens in order', () => {
+    expect(SCREEN_ORDER).toHaveLength(5);
+    expect(SCREEN_ORDER).toEqual([
+      Screen.Dashboard,
+      Screen.Areas,
+      Screen.Goals,
+      Screen.Tasks,
+      Screen.Habits,
+    ]);
+  });
+
+  it('maps keys 1-5 to screens', () => {
+    expect(Object.keys(SCREEN_KEYS)).toHaveLength(5);
+    expect(SCREEN_KEYS['1']).toBe(Screen.Dashboard);
+    expect(SCREEN_KEYS['2']).toBe(Screen.Areas);
+    expect(SCREEN_KEYS['3']).toBe(Screen.Goals);
+    expect(SCREEN_KEYS['4']).toBe(Screen.Tasks);
+    expect(SCREEN_KEYS['5']).toBe(Screen.Habits);
+  });
+
+  it('has labels for all screens', () => {
+    for (const screen of SCREEN_ORDER) {
+      expect(SCREEN_LABELS[screen]).toBeDefined();
+      expect(typeof SCREEN_LABELS[screen]).toBe('string');
+      expect(SCREEN_LABELS[screen]!.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('TUI themes', () => {
+  const requiredTokens: (keyof ColorTokens)[] = [
+    'bg', 'bgPanel', 'bgHighlight',
+    'textPrimary', 'textSecondary', 'textAccent',
+    'success', 'warning', 'error',
+    'priorityLow', 'priorityMed', 'priorityHigh', 'priorityUrgent',
+    'accent1', 'accent2',
+    'streakFire', 'progressFill', 'progressTrack',
+    'border', 'borderActive',
+    'tabActive', 'tabInactive',
+  ];
+
+  it('has 3 themes registered', () => {
+    expect(themeNames).toHaveLength(3);
+    expect(themeNames).toContain('neon');
+    expect(themeNames).toContain('matrix');
+    expect(themeNames).toContain('purple');
+  });
+
+  for (const name of ['neon', 'matrix', 'purple']) {
+    describe(`${name} theme`, () => {
+      it('has a name property', () => {
+        expect(themes[name]!.name).toBe(name);
+      });
+
+      it('has all required color tokens', () => {
+        const colors = themes[name]!.colors;
+        for (const token of requiredTokens) {
+          expect(colors[token]).toBeDefined();
+          expect(typeof colors[token]).toBe('string');
+          expect(colors[token]!.length).toBeGreaterThan(0);
+        }
+      });
+
+      it('all color tokens are valid hex colors', () => {
+        const colors = themes[name]!.colors;
+        for (const token of requiredTokens) {
+          expect(colors[token]).toMatch(/^#[0-9a-fA-F]{6}$/);
+        }
+      });
+    });
+  }
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,8 @@
     "moduleResolution": "NodeNext",
     "esModuleInterop": true,
     "strict": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "react",
     "outDir": "dist",
     "rootDir": "src",
     "declaration": true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  esbuild: {
+    jsx: 'automatic',
+    jsxImportSource: 'react',
+  },
   test: {
     globals: true,
     testTimeout: 10000,


### PR DESCRIPTION
## Summary

- Implements a full interactive terminal UI launched via `plan tui` using Ink v5 (React for CLI)
- 5 screens: Dashboard, Areas, Goals, Tasks, Habits — with keyboard navigation, search, and live mutations
- 3 color themes (Neon, Matrix, Purple) switchable at runtime with `t`
- Animations: streak fire pulsing, progress bar fill, confetti burst, overdue task pulsing
- Dynamic import ensures React/Ink are never loaded for regular CLI commands

## Architecture

```
plan tui --theme neon
  → tui.command.ts: ensureInitialized(), dynamic import('../tui/app.js')
    → app.tsx: render(<App>)
      ServicesContext (existing container)
        ThemeContext (3 themes via React Context)
          Layout → TopBar / BottomBar / Screen router
```

New files follow the existing layered architecture:
- `src/tui/types.ts` — Screen enum, key mappings
- `src/tui/themes/` — ColorTokens interface + 3 theme implementations
- `src/tui/hooks/` — 6 custom hooks (theme, screen, services, refresh, animation, global keys)
- `src/tui/components/` — 11 reusable UI components
- `src/tui/screens/` — 5 screen implementations
- `src/tui/app.tsx` — Root component + entry point

## Test plan

- [x] `npm run build` — compiles with no errors
- [x] `npm run lint` — no TypeScript errors
- [x] `npm test` — all 137 tests pass (113 existing + 24 new)
  - Unit: theme token validation, screen enum correctness
  - Integration: ink-testing-library renders each screen with test DB
  - E2E: `plan tui` registers in help, shows --theme option
- [ ] Manual: `plan tui` → dashboard → Tab through screens → check habit → cycle themes → search → quit

🤖 Generated with [Claude Code](https://claude.com/claude-code)