### PR TITLE
💄 Improve mobile UI/UX across all web pages

### DIFF
--- a/packages/web/src/components/layout/mobile-header.tsx
+++ b/packages/web/src/components/layout/mobile-header.tsx
@@ -12,10 +12,10 @@ export function MobileHeader({ onMenuToggle, onChatToggle }: MobileHeaderProps) 
   const currentSpace = spaces?.find(s => s.id === spaceId);
 
   return (
-    <div className="md:hidden flex items-center justify-between px-3 py-2 border-b border-[var(--color-border)] bg-[var(--color-bg-panel)]">
+    <div className="md:hidden flex items-center justify-between px-3 py-2.5 border-b border-[var(--color-border)] bg-[var(--color-bg-panel)]">
       <button
         onClick={onMenuToggle}
-        className="p-1.5 rounded text-[var(--color-text-secondary)] hover:text-[var(--color-text-accent)] hover:bg-[var(--color-bg-highlight)]"
+        className="p-2 -ml-1 rounded-lg text-[var(--color-text-secondary)] hover:text-[var(--color-text-accent)] hover:bg-[var(--color-bg-highlight)] active:opacity-70 transition-colors"
         aria-label="Toggle menu"
       >
         <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
@@ -30,7 +30,7 @@ export function MobileHeader({ onMenuToggle, onChatToggle }: MobileHeaderProps) 
       </span>
       <button
         onClick={onChatToggle}
-        className="p-1.5 rounded text-[var(--color-text-secondary)] hover:text-[var(--color-text-accent)] hover:bg-[var(--color-bg-highlight)]"
+        className="p-2 -mr-1 rounded-lg text-[var(--color-text-secondary)] hover:text-[var(--color-text-accent)] hover:bg-[var(--color-bg-highlight)] active:opacity-70 transition-colors"
         aria-label="Toggle chat"
       >
         <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/packages/web/src/components/shared/confirm-dialog.tsx
+++ b/packages/web/src/components/shared/confirm-dialog.tsx
@@ -32,19 +32,19 @@ export function ConfirmDialog({ open, title, message, onConfirm, onCancel }: Con
       className="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-panel)] text-[var(--color-text-primary)] p-0 backdrop:bg-black/50"
       onClose={onCancel}
     >
-      <div className="p-6 min-w-80">
+      <div className="p-6 min-w-[min(320px,90vw)]">
         <h3 className="text-lg font-semibold text-[var(--color-text-accent)] mb-2">{title}</h3>
         <p className="text-sm text-[var(--color-text-secondary)] mb-6">{message}</p>
         <div className="flex justify-end gap-3">
           <button
             onClick={onCancel}
-            className="px-4 py-2 text-sm rounded border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-highlight)]"
+            className="px-4 py-2 text-sm rounded-lg border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-highlight)] active:opacity-80 transition-colors"
           >
             Cancel
           </button>
           <button
             onClick={onConfirm}
-            className="px-4 py-2 text-sm rounded bg-[var(--color-error)] text-white hover:opacity-90"
+            className="px-4 py-2 text-sm rounded-lg bg-[var(--color-error)] text-white hover:opacity-90 active:opacity-80 transition-opacity"
           >
             Delete
           </button>

--- a/packages/web/src/components/shared/inline-form.tsx
+++ b/packages/web/src/components/shared/inline-form.tsx
@@ -39,7 +39,7 @@ export function InlineForm({ open, initialValues = {}, fields, onSubmit, onCance
       >
         {fields.map((field, i) => (
           <div key={field.name}>
-            <label className="block text-xs text-[var(--color-text-secondary)] mb-1">{field.label}</label>
+            <label className="block text-xs text-[var(--color-text-secondary)] mb-1.5">{field.label}</label>
             <input
               ref={i === 0 ? firstInputRef : undefined}
               type={field.type ?? 'text'}
@@ -48,7 +48,7 @@ export function InlineForm({ open, initialValues = {}, fields, onSubmit, onCance
               required={field.required}
               onFocus={() => setInputFocused(true)}
               onBlur={() => setInputFocused(false)}
-              className="w-full px-3 py-2 rounded bg-[var(--color-bg)] border border-[var(--color-border)] text-[var(--color-text-primary)] text-sm focus:outline-none focus:border-[var(--color-border-active)]"
+              className="w-full px-3 py-2.5 rounded-lg bg-[var(--color-bg)] border border-[var(--color-border)] text-[var(--color-text-primary)] text-sm focus:outline-none focus:border-[var(--color-border-active)] transition-colors"
             />
           </div>
         ))}
@@ -56,13 +56,13 @@ export function InlineForm({ open, initialValues = {}, fields, onSubmit, onCance
           <button
             type="button"
             onClick={onCancel}
-            className="px-3 py-1.5 text-sm rounded border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-highlight)]"
+            className="px-4 py-2 text-sm rounded-lg border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-highlight)] active:opacity-80 transition-colors"
           >
             Cancel
           </button>
           <button
             type="submit"
-            className="px-3 py-1.5 text-sm rounded bg-[var(--color-accent-1)] text-[var(--color-bg)] font-medium hover:opacity-90"
+            className="px-4 py-2 text-sm rounded-lg bg-[var(--color-accent-1)] text-[var(--color-bg)] font-medium hover:opacity-90 active:opacity-80 transition-opacity"
           >
             {submitLabel}
           </button>

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -29,6 +29,11 @@ body {
   margin: 0;
   font-family: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace;
   -webkit-font-smoothing: antialiased;
+  -webkit-tap-highlight-color: transparent;
+}
+
+html {
+  scroll-behavior: smooth;
 }
 
 * {

--- a/packages/web/src/pages/areas.tsx
+++ b/packages/web/src/pages/areas.tsx
@@ -108,7 +108,7 @@ export function AreasPage() {
         <h1 className="text-2xl font-bold text-[var(--color-text-accent)]">Areas</h1>
         <button
           onClick={() => setShowAdd(true)}
-          className="px-3 py-1.5 text-sm rounded bg-[var(--color-accent-1)] text-[var(--color-bg)] font-medium hover:opacity-90"
+          className="px-4 py-2 text-sm rounded-lg bg-[var(--color-accent-1)] text-[var(--color-bg)] font-medium hover:opacity-90 active:opacity-80 transition-opacity"
         >
           + New Area
         </button>
@@ -147,13 +147,13 @@ export function AreasPage() {
         />
       )}
 
-      <div className="space-y-1">
+      <div className="space-y-2">
         {areas?.map((area, i) => (
           <button
             key={area.id}
             onClick={() => setDetailId(area.id)}
             data-selected={i === selectedIdx ? '' : undefined}
-            className={`w-full text-left px-4 py-3 rounded flex flex-col md:flex-row md:items-center justify-between gap-1 transition-colors ${
+            className={`w-full text-left px-4 py-3 rounded-lg flex flex-col md:flex-row md:items-center justify-between gap-1.5 transition-colors ${
               i === selectedIdx
                 ? 'bg-[var(--color-bg-highlight)] border border-[var(--color-border-active)]'
                 : 'hover:bg-[var(--color-bg-highlight)] border border-transparent'
@@ -172,6 +172,12 @@ export function AreasPage() {
             </div>
           </button>
         ))}
+        {areas?.length === 0 && (
+          <div className="text-center py-12">
+            <p className="text-3xl mb-2">#</p>
+            <p className="text-sm text-[var(--color-text-secondary)]">No areas yet — press n to create one</p>
+          </div>
+        )}
       </div>
 
       <ConfirmDialog

--- a/packages/web/src/pages/dashboard.tsx
+++ b/packages/web/src/pages/dashboard.tsx
@@ -74,28 +74,35 @@ export function DashboardPage() {
       {/* Summary cards */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-4">
         <Panel>
+          <div className="flex items-center justify-between mb-1">
+            <p className="text-xs text-[var(--color-text-secondary)]">Tasks Due</p>
+            <span className="text-base opacity-60">{'>'}</span>
+          </div>
           <p className="text-2xl font-bold text-[var(--color-accent-1)]">{summary.tasksDue}</p>
-          <p className="text-xs text-[var(--color-text-secondary)]">Tasks Due</p>
         </Panel>
         <Panel>
-          <p className="text-2xl font-bold text-[var(--color-error)]">{summary.tasksOverdue}</p>
-          <p className="text-xs text-[var(--color-text-secondary)]">Overdue</p>
+          <div className="flex items-center justify-between mb-1">
+            <p className="text-xs text-[var(--color-text-secondary)]">Overdue</p>
+            <span className="text-base opacity-60">!</span>
+          </div>
+          <p className={`text-2xl font-bold ${summary.tasksOverdue > 0 ? 'text-[var(--color-error)]' : 'text-[var(--color-text-secondary)]'}`}>{summary.tasksOverdue}</p>
         </Panel>
         <Panel>
+          <div className="flex items-center justify-between mb-1">
+            <p className="text-xs text-[var(--color-text-secondary)]">Habits Done</p>
+            <span className="text-base opacity-60">+</span>
+          </div>
           <p className="text-2xl font-bold text-[var(--color-success)]">{summary.habitsDone}/{summary.habitsDue}</p>
-          <p className="text-xs text-[var(--color-text-secondary)]">Habits Done</p>
         </Panel>
         <Panel>
+          <div className="flex items-center justify-between mb-1">
+            <p className="text-xs text-[var(--color-text-secondary)]">{summary.bestActiveStreak ? summary.bestActiveStreak.habit : 'Streaks'}</p>
+            <span className="text-base opacity-60">~</span>
+          </div>
           {summary.bestActiveStreak ? (
-            <>
-              <p className="text-2xl font-bold text-[var(--color-streak-fire)]">{summary.bestActiveStreak.streak}</p>
-              <p className="text-xs text-[var(--color-text-secondary)] truncate">{summary.bestActiveStreak.habit}</p>
-            </>
+            <p className="text-2xl font-bold text-[var(--color-streak-fire)]">{summary.bestActiveStreak.streak}</p>
           ) : (
-            <>
-              <p className="text-2xl font-bold text-[var(--color-text-secondary)]">--</p>
-              <p className="text-xs text-[var(--color-text-secondary)]">No streaks</p>
-            </>
+            <p className="text-2xl font-bold text-[var(--color-text-secondary)]">--</p>
           )}
         </Panel>
       </div>
@@ -144,27 +151,27 @@ export function DashboardPage() {
               <li
                 key={habit.id}
                 data-selected={i === selectedIdx ? '' : undefined}
-                className={`flex items-center gap-3 text-sm rounded px-2 py-1 transition-colors ${
-                  i === selectedIdx ? 'bg-[var(--color-bg-highlight)]' : ''
+                className={`flex items-center gap-3 text-sm rounded-lg px-3 py-2 transition-colors cursor-pointer ${
+                  i === selectedIdx ? 'bg-[var(--color-bg-highlight)]' : 'hover:bg-[var(--color-bg-highlight)]'
                 }`}
+                onClick={() => {
+                  if (habit.done) {
+                    uncheckHabit.mutate({ id: habit.id });
+                  } else {
+                    checkHabit.mutate({ id: habit.id });
+                  }
+                }}
               >
-                <button
-                  onClick={() => {
-                    if (habit.done) {
-                      uncheckHabit.mutate({ id: habit.id });
-                    } else {
-                      checkHabit.mutate({ id: habit.id });
-                    }
-                  }}
-                  className={`w-5 h-5 rounded border flex items-center justify-center transition-colors ${
+                <div
+                  className={`w-6 h-6 rounded border-2 flex-shrink-0 flex items-center justify-center text-xs transition-colors ${
                     habit.done
                       ? 'bg-[var(--color-success)] border-[var(--color-success)] text-[var(--color-bg)]'
                       : 'border-[var(--color-border)] hover:border-[var(--color-border-active)]'
                   }`}
                 >
                   {habit.done ? '\u2713' : null}
-                </button>
-                <span className={habit.done ? 'text-[var(--color-text-secondary)] line-through' : 'text-[var(--color-text-primary)]'}>
+                </div>
+                <span className={`flex-1 ${habit.done ? 'text-[var(--color-text-secondary)] line-through' : 'text-[var(--color-text-primary)]'}`}>
                   {habit.title}
                 </span>
                 <StreakDisplay current={habit.currentStreak} best={habit.bestStreak} />

--- a/packages/web/src/pages/goals.tsx
+++ b/packages/web/src/pages/goals.tsx
@@ -128,17 +128,17 @@ export function GoalsPage() {
     <div className="space-y-4 max-w-2xl">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold text-[var(--color-text-accent)]">Goals</h1>
-        <button onClick={() => setShowAdd(true)} className="px-3 py-1.5 text-sm rounded bg-[var(--color-accent-1)] text-[var(--color-bg)] font-medium hover:opacity-90">
+        <button onClick={() => setShowAdd(true)} className="px-4 py-2 text-sm rounded-lg bg-[var(--color-accent-1)] text-[var(--color-bg)] font-medium hover:opacity-90 active:opacity-80 transition-opacity">
           + New Goal
         </button>
       </div>
 
-      <div className="flex gap-2">
+      <div className="flex gap-1.5 bg-[var(--color-bg-panel)] rounded-lg p-1 border border-[var(--color-border)]">
         {FILTERS.map((f) => (
           <button
             key={f}
             onClick={() => setFilter(f)}
-            className={`px-3 py-1 text-xs rounded ${filter === f ? 'bg-[var(--color-tab-active)] text-[var(--color-bg)]' : 'text-[var(--color-tab-inactive)] hover:text-[var(--color-text-primary)]'}`}
+            className={`flex-1 px-3 py-1.5 text-xs rounded-md font-medium transition-colors ${filter === f ? 'bg-[var(--color-tab-active)] text-[var(--color-bg)]' : 'text-[var(--color-tab-inactive)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-highlight)]'}`}
           >
             {f}
           </button>
@@ -181,25 +181,32 @@ export function GoalsPage() {
         />
       )}
 
-      <div className="space-y-1">
+      <div className="space-y-2">
         {goals?.map((goal, i) => (
           <button
             key={goal.id}
             onClick={() => setDetailId(goal.id)}
             data-selected={i === selectedIdx ? '' : undefined}
-            className={`w-full text-left px-4 py-3 rounded transition-colors ${
+            className={`w-full text-left px-4 py-3 rounded-lg transition-colors ${
               i === selectedIdx ? 'bg-[var(--color-bg-highlight)] border border-[var(--color-border-active)]' : 'hover:bg-[var(--color-bg-highlight)] border border-transparent'
             }`}
           >
-            <div className="flex items-center gap-2 mb-1">
-              <span className="text-sm font-medium text-[var(--color-text-primary)]">{goal.title}</span>
+            <span className="text-sm font-medium text-[var(--color-text-primary)]">{goal.title}</span>
+            <div className="flex items-center gap-2 mt-1.5">
               <StatusBadge status={goal.status} />
               <PriorityBadge priority={goal.priority} />
             </div>
-            <ProgressBar value={goal.progress} className="w-full max-w-48" />
+            <ProgressBar value={goal.progress} className="w-full mt-2" />
           </button>
         ))}
-        {goals?.length === 0 && <p className="text-sm text-[var(--color-text-secondary)]">No goals matching filter</p>}
+        {goals?.length === 0 && (
+          <div className="text-center py-12">
+            <p className="text-3xl mb-2">🎯</p>
+            <p className="text-sm text-[var(--color-text-secondary)]">
+              {filter === 'all' ? 'No goals yet — press n to create one' : `No ${filter} goals`}
+            </p>
+          </div>
+        )}
       </div>
 
       <ConfirmDialog

--- a/packages/web/src/pages/habits.tsx
+++ b/packages/web/src/pages/habits.tsx
@@ -83,23 +83,23 @@ export function HabitsPage() {
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold text-[var(--color-text-accent)]">
           Habits
-          {allDone && <span className="ml-2 text-[var(--color-success)]">\u2728 All done!</span>}
+          {allDone && <span className="ml-2 text-[var(--color-success)]">{'\u2728'} All done!</span>}
         </h1>
-        <button onClick={() => setShowAdd(true)} className="px-3 py-1.5 text-sm rounded bg-[var(--color-accent-1)] text-[var(--color-bg)] font-medium hover:opacity-90">
+        <button onClick={() => setShowAdd(true)} className="px-4 py-2 text-sm rounded-lg bg-[var(--color-accent-1)] text-[var(--color-bg)] font-medium hover:opacity-90 active:opacity-80 transition-opacity">
           + New Habit
         </button>
       </div>
 
-      <div className="flex gap-2">
+      <div className="flex gap-1.5 bg-[var(--color-bg-panel)] rounded-lg p-1 border border-[var(--color-border)] max-w-[200px]">
         <button
           onClick={() => { setViewMode('today'); setSelectedIdx(0); }}
-          className={`px-3 py-1 text-xs rounded ${viewMode === 'today' ? 'bg-[var(--color-tab-active)] text-[var(--color-bg)]' : 'text-[var(--color-tab-inactive)] hover:text-[var(--color-text-primary)]'}`}
+          className={`flex-1 px-3 py-1.5 text-xs rounded-md font-medium transition-colors ${viewMode === 'today' ? 'bg-[var(--color-tab-active)] text-[var(--color-bg)]' : 'text-[var(--color-tab-inactive)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-highlight)]'}`}
         >
           Today
         </button>
         <button
           onClick={() => { setViewMode('all'); setSelectedIdx(0); }}
-          className={`px-3 py-1 text-xs rounded ${viewMode === 'all' ? 'bg-[var(--color-tab-active)] text-[var(--color-bg)]' : 'text-[var(--color-tab-inactive)] hover:text-[var(--color-text-primary)]'}`}
+          className={`flex-1 px-3 py-1.5 text-xs rounded-md font-medium transition-colors ${viewMode === 'all' ? 'bg-[var(--color-tab-active)] text-[var(--color-bg)]' : 'text-[var(--color-tab-inactive)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-highlight)]'}`}
         >
           All
         </button>
@@ -135,14 +135,14 @@ export function HabitsPage() {
         />
       )}
 
-      <div className="space-y-1">
+      <div className="space-y-2">
         {displayItems?.map((habit, i) => {
           const isDone = 'done' in habit ? habit.done : false;
           return (
             <div
               key={habit.id}
               data-selected={i === selectedIdx ? '' : undefined}
-              className={`px-4 py-3 rounded flex items-center justify-between gap-2 transition-colors cursor-pointer ${
+              className={`px-4 py-3 rounded-lg flex items-center justify-between gap-2 transition-colors cursor-pointer ${
                 i === selectedIdx ? 'bg-[var(--color-bg-highlight)] border border-[var(--color-border-active)]' : 'hover:bg-[var(--color-bg-highlight)] border border-transparent'
               }`}
               onClick={() => {
@@ -158,7 +158,7 @@ export function HabitsPage() {
             >
               <div className="flex items-center gap-3 min-w-0">
                 {isToday && (
-                  <div className={`w-5 h-5 rounded border flex-shrink-0 flex items-center justify-center text-xs ${
+                  <div className={`w-6 h-6 rounded border-2 flex-shrink-0 flex items-center justify-center text-xs transition-colors ${
                     isDone
                       ? 'bg-[var(--color-success)] border-[var(--color-success)] text-[var(--color-bg)]'
                       : 'border-[var(--color-border)]'
@@ -176,9 +176,12 @@ export function HabitsPage() {
           );
         })}
         {displayItems?.length === 0 && (
-          <p className="text-sm text-[var(--color-text-secondary)]">
-            {isToday ? 'No habits due today' : 'No habits yet'}
-          </p>
+          <div className="text-center py-12">
+            <p className="text-3xl mb-2">{isToday ? '✅' : '🔄'}</p>
+            <p className="text-sm text-[var(--color-text-secondary)]">
+              {isToday ? 'No habits due today' : 'No habits yet — press n to create one'}
+            </p>
+          </div>
         )}
       </div>
 

--- a/packages/web/src/pages/tasks.tsx
+++ b/packages/web/src/pages/tasks.tsx
@@ -88,17 +88,17 @@ export function TasksPage() {
     <div className="space-y-4 max-w-2xl">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold text-[var(--color-text-accent)]">Tasks</h1>
-        <button onClick={() => setShowAdd(true)} className="px-3 py-1.5 text-sm rounded bg-[var(--color-accent-1)] text-[var(--color-bg)] font-medium hover:opacity-90">
+        <button onClick={() => setShowAdd(true)} className="px-4 py-2 text-sm rounded-lg bg-[var(--color-accent-1)] text-[var(--color-bg)] font-medium hover:opacity-90 active:opacity-80 transition-opacity">
           + New Task
         </button>
       </div>
 
-      <div className="flex gap-2">
+      <div className="flex gap-1.5 bg-[var(--color-bg-panel)] rounded-lg p-1 border border-[var(--color-border)]">
         {FILTERS.map((f) => (
           <button
             key={f}
             onClick={() => setFilter(f)}
-            className={`px-3 py-1 text-xs rounded ${filter === f ? 'bg-[var(--color-tab-active)] text-[var(--color-bg)]' : 'text-[var(--color-tab-inactive)] hover:text-[var(--color-text-primary)]'}`}
+            className={`flex-1 px-3 py-1.5 text-xs rounded-md font-medium transition-colors ${filter === f ? 'bg-[var(--color-tab-active)] text-[var(--color-bg)]' : 'text-[var(--color-tab-inactive)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-highlight)]'}`}
           >
             {f.replace('_', ' ')}
           </button>
@@ -141,52 +141,63 @@ export function TasksPage() {
         />
       )}
 
-      <div className="space-y-1">
+      <div className="space-y-2">
         {tasks?.map((task, i) => {
           const overdue = task.dueDate && task.dueDate < today && task.status !== 'done';
           return (
             <div
               key={task.id}
               data-selected={i === selectedIdx ? '' : undefined}
-              className={`px-4 py-3 rounded flex items-center gap-3 transition-colors cursor-pointer ${
+              className={`px-4 py-3 rounded-lg transition-colors cursor-pointer ${
                 i === selectedIdx ? 'bg-[var(--color-bg-highlight)] border border-[var(--color-border-active)]' : 'hover:bg-[var(--color-bg-highlight)] border border-transparent'
               }`}
               onClick={() => setSelectedIdx(i)}
             >
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  if (task.status !== 'done') {
-                    tasksApi.markDone(task.id).then(() => {
-                      qc.invalidateQueries({ queryKey: ['tasks'] });
-                      qc.invalidateQueries({ queryKey: ['status'] });
-                    });
-                  }
-                }}
-                className={`w-5 h-5 rounded border flex-shrink-0 flex items-center justify-center text-xs ${
-                  task.status === 'done'
-                    ? 'bg-[var(--color-success)] border-[var(--color-success)] text-[var(--color-bg)]'
-                    : 'border-[var(--color-border)] hover:border-[var(--color-border-active)]'
-                }`}
-              >
-                {task.status === 'done' ? '\u2713' : null}
-              </button>
-              <span className={`flex-1 min-w-0 text-sm ${task.status === 'done' ? 'line-through text-[var(--color-text-secondary)]' : 'text-[var(--color-text-primary)]'}`}>
-                {task.title}
-              </span>
-              <div className="flex items-center gap-2 flex-shrink-0 flex-wrap">
-                <StatusBadge status={task.status} />
-                <PriorityBadge priority={task.priority} />
-                {task.dueDate && (
-                  <span className={`text-xs whitespace-nowrap ${overdue ? 'text-[var(--color-error)]' : 'text-[var(--color-text-secondary)]'}`}>
-                    {overdue ? 'Overdue: ' : ''}{task.dueDate}
+              <div className="flex items-start gap-3">
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (task.status !== 'done') {
+                      tasksApi.markDone(task.id).then(() => {
+                        qc.invalidateQueries({ queryKey: ['tasks'] });
+                        qc.invalidateQueries({ queryKey: ['status'] });
+                      });
+                    }
+                  }}
+                  className={`w-6 h-6 mt-0.5 rounded border-2 flex-shrink-0 flex items-center justify-center text-xs transition-colors ${
+                    task.status === 'done'
+                      ? 'bg-[var(--color-success)] border-[var(--color-success)] text-[var(--color-bg)]'
+                      : 'border-[var(--color-border)] hover:border-[var(--color-border-active)]'
+                  }`}
+                >
+                  {task.status === 'done' ? '\u2713' : null}
+                </button>
+                <div className="flex-1 min-w-0">
+                  <span className={`text-sm leading-snug ${task.status === 'done' ? 'line-through text-[var(--color-text-secondary)]' : 'text-[var(--color-text-primary)]'}`}>
+                    {task.title}
                   </span>
-                )}
+                  <div className="flex items-center gap-2 mt-1.5 flex-wrap">
+                    <StatusBadge status={task.status} />
+                    <PriorityBadge priority={task.priority} />
+                    {task.dueDate && (
+                      <span className={`text-xs ${overdue ? 'text-[var(--color-error)] font-medium' : 'text-[var(--color-text-secondary)]'}`}>
+                        {overdue ? 'Overdue: ' : 'Due: '}{task.dueDate}
+                      </span>
+                    )}
+                  </div>
+                </div>
               </div>
             </div>
           );
         })}
-        {tasks?.length === 0 && <p className="text-sm text-[var(--color-text-secondary)]">No tasks matching filter</p>}
+        {tasks?.length === 0 && (
+          <div className="text-center py-12">
+            <p className="text-3xl mb-2">{ filter === 'done' ? '🎯' : '📋' }</p>
+            <p className="text-sm text-[var(--color-text-secondary)]">
+              {filter === 'all' ? 'No tasks yet — press n to create one' : `No ${filter.replace('_', ' ')} tasks`}
+            </p>
+          </div>
+        )}
       </div>
 
       <ConfirmDialog


### PR DESCRIPTION
- Redesign task cards with stacked layout (title above metadata)
  for better readability on narrow screens
- Upgrade filter tabs to segmented control style with bg panel,
  larger touch targets, and hover states
- Add descriptive empty states with icons and keyboard hints
- Increase checkbox size (5->6, border-2) for better touch targets
- Make action buttons larger with rounded-lg and active states
- Polish dashboard summary cards with label-above-value layout
- Make dashboard habit items clickable with hover state
- Improve mobile header touch targets with larger hit areas
- Add smooth scrolling and disable tap highlight for mobile
- Use consistent rounded-lg and space-y-2 gap across all list pages
- Polish inline forms and confirm dialogs with better spacing

https://claude.ai/code/session_016iWJWp1Q7tsKfEnGF8AvqF