### PR TITLE
🐛 Fix login for admin-added users (username normalization)

### DIFF
--- a/packages/api/src/routes/admin.routes.ts
+++ b/packages/api/src/routes/admin.routes.ts
@@ -1,5 +1,5 @@
 import { Hono, type Context } from 'hono';
-import { generateId } from '@planner/core';
+import { generateId, normalizeUsername } from '@planner/core';
 import type { ApiContainer } from '../container.js';
 
 export function createAdminRoutes(container: ApiContainer): Hono {
@@ -12,7 +12,7 @@ export function createAdminRoutes(container: ApiContainer): Hono {
     if (!userId) return c.json({ error: 'Unauthorized' }, 401);
 
     const [provider, username] = userId.split(':');
-    if (!provider || !username || !allowedUserRepo.isAdmin(provider, username)) {
+    if (!provider || !username || !allowedUserRepo.isAdmin(provider, normalizeUsername(username))) {
       return c.json({ error: 'Admin access required' }, 403);
     }
     await next();
@@ -28,7 +28,7 @@ export function createAdminRoutes(container: ApiContainer): Hono {
   app.post('/allowed-users', async (c) => {
     const body = await c.req.json() as { provider?: string; username?: string };
     const provider = body.provider ?? 'github';
-    const username = body.username?.trim();
+    const username = body.username ? normalizeUsername(body.username) : '';
 
     if (!username) {
       return c.json({ error: 'Username is required' }, 400);

--- a/packages/api/src/routes/auth.routes.ts
+++ b/packages/api/src/routes/auth.routes.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { generateId } from '@planner/core';
+import { generateId, normalizeUsername } from '@planner/core';
 import type { ApiContainer } from '../container.js';
 
 export function createAuthRoutes(container: ApiContainer): Hono {
@@ -51,13 +51,15 @@ export function createAuthRoutes(container: ApiContainer): Hono {
       return c.json({ error: 'Failed to get user info' }, 400);
     }
 
+    const login = normalizeUsername(user.login);
+
     // Check allowlist (database)
-    if (!allowedUserRepo.isAllowed('github', user.login)) {
+    if (!allowedUserRepo.isAllowed('github', login)) {
       return c.json({ error: 'User not authorized' }, 403);
     }
 
     // Create session
-    const session = createSession(sessionRepo, `github:${user.login}`);
+    const session = createSession(sessionRepo, `github:${login}`);
     const secure = c.req.header('x-forwarded-proto') === 'https' ? '; Secure' : '';
     c.header('Set-Cookie', `session=${session.id}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${30 * 24 * 60 * 60}${secure}`);
     return c.redirect('/');
@@ -117,13 +119,15 @@ export function createAuthRoutes(container: ApiContainer): Hono {
       return c.json({ error: 'Failed to get user info' }, 400);
     }
 
+    const email = normalizeUsername(user.email);
+
     // Check allowlist (database)
-    if (!allowedUserRepo.isAllowed('google', user.email)) {
+    if (!allowedUserRepo.isAllowed('google', email)) {
       return c.json({ error: 'User not authorized' }, 403);
     }
 
     // Create session
-    const session = createSession(sessionRepo, `google:${user.email}`);
+    const session = createSession(sessionRepo, `google:${email}`);
     const secure = c.req.header('x-forwarded-proto') === 'https' ? '; Secure' : '';
     c.header('Set-Cookie', `session=${session.id}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${30 * 24 * 60 * 60}${secure}`);
     return c.redirect('/');
@@ -155,7 +159,7 @@ export function createAuthRoutes(container: ApiContainer): Hono {
       return c.json({ authenticated: false });
     }
     const [provider, username] = session.userId.split(':');
-    const isAdmin = provider && username ? allowedUserRepo.isAdmin(provider, username) : false;
+    const isAdmin = provider && username ? allowedUserRepo.isAdmin(provider, normalizeUsername(username)) : false;
     return c.json({ authenticated: true, userId: session.userId, isAdmin });
   });
 

--- a/packages/core/src/db/migrate.ts
+++ b/packages/core/src/db/migrate.ts
@@ -1,6 +1,7 @@
 import { sql } from 'drizzle-orm';
 import type { DB } from './connection.js';
 import { generateId } from '../utils/id.js';
+import { normalizeUsername } from '../utils/identity.js';
 import { today } from '../utils/date.js';
 
 const STATEMENTS = [
@@ -129,8 +130,16 @@ export function runMigrations(db: DB): void {
   // Backfill: create a default space and assign orphaned rows
   backfillDefaultSpace(db);
 
+  // Normalize any pre-existing allowlist rows (idempotent: LOWER + TRIM + strip leading @)
+  normalizeAllowedUsers(db);
+
   // Seed allowed_users from env vars if table is empty
   seedAllowedUsersFromEnv(db);
+}
+
+function normalizeAllowedUsers(db: DB): void {
+  db.run(sql`UPDATE allowed_users SET username = LOWER(TRIM(username)) WHERE username != LOWER(TRIM(username))`);
+  db.run(sql`UPDATE allowed_users SET username = SUBSTR(username, 2) WHERE username LIKE '@%'`);
 }
 
 function seedAllowedUsersFromEnv(db: DB): void {
@@ -140,7 +149,7 @@ function seedAllowedUsersFromEnv(db: DB): void {
   const now = new Date().toISOString();
 
   // Seed GitHub users
-  const githubUsers = (process.env.PLANNER_ALLOWED_GITHUB_USERS ?? '').split(',').map(u => u.trim()).filter(Boolean);
+  const githubUsers = (process.env.PLANNER_ALLOWED_GITHUB_USERS ?? '').split(',').map(normalizeUsername).filter(Boolean);
   for (let i = 0; i < githubUsers.length; i++) {
     const id = generateId();
     const isAdmin = i === 0 ? 1 : 0; // First user is admin
@@ -148,7 +157,7 @@ function seedAllowedUsersFromEnv(db: DB): void {
   }
 
   // Seed Google emails
-  const googleEmails = (process.env.PLANNER_ALLOWED_GOOGLE_EMAILS ?? '').split(',').map(e => e.trim()).filter(Boolean);
+  const googleEmails = (process.env.PLANNER_ALLOWED_GOOGLE_EMAILS ?? '').split(',').map(normalizeUsername).filter(Boolean);
   for (const email of googleEmails) {
     const id = generateId();
     const isAdmin = githubUsers.length === 0 ? 1 : 0; // Admin if no GitHub users were added

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,3 +54,4 @@ export { today, toISODate, parseDate, dayOfWeek, isoWeek, addDays, diffDays, for
 export { formatOutput } from './utils/output.js';
 export { ensureInitialized } from './utils/guard.js';
 export { getPlannerDir, getDbPath, getConfigPath } from './utils/paths.js';
+export { normalizeUsername } from './utils/identity.js';

--- a/packages/core/src/utils/identity.ts
+++ b/packages/core/src/utils/identity.ts
@@ -1,0 +1,6 @@
+// GitHub usernames are case-insensitive; email local-parts are case-sensitive per
+// RFC 5321 but treated case-insensitively by every major provider. Lowercasing on
+// both write and read sides avoids byte-level mismatches in the allowlist lookup.
+export function normalizeUsername(value: string): string {
+  return value.trim().replace(/^@/, '').toLowerCase();
+}

--- a/tests/unit/identity.test.ts
+++ b/tests/unit/identity.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeUsername } from '@planner/core';
+
+describe('normalizeUsername', () => {
+  it('lowercases mixed-case GitHub logins', () => {
+    expect(normalizeUsername('Ye-Kart')).toBe('ye-kart');
+    expect(normalizeUsername('OCTOCAT')).toBe('octocat');
+  });
+
+  it('strips a leading @', () => {
+    expect(normalizeUsername('@octocat')).toBe('octocat');
+    expect(normalizeUsername('@Ye-Kart')).toBe('ye-kart');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeUsername('  octocat  ')).toBe('octocat');
+    expect(normalizeUsername('\tOctocat\n')).toBe('octocat');
+  });
+
+  it('lowercases email addresses', () => {
+    expect(normalizeUsername('Alice@Example.COM')).toBe('alice@example.com');
+  });
+
+  it('only strips the first leading @, preserving @ inside emails', () => {
+    expect(normalizeUsername('@alice@example.com')).toBe('alice@example.com');
+  });
+
+  it('is idempotent', () => {
+    const once = normalizeUsername('  @Ye-Kart  ');
+    expect(normalizeUsername(once)).toBe(once);
+  });
+});


### PR DESCRIPTION
## Summary

Users added via the admin panel couldn't log in if their entered casing didn't exactly match GitHub's canonical `login` — a subtle data bug caused by SQLite's default **case-sensitive `TEXT` comparison** in `allowedUserRepo.findByProviderAndUsername`. A leading `@` (easy to accidentally paste from a GitHub mention) caused the same failure.

This PR normalizes usernames at every layer so the comparison can never miss a legitimately-allowlisted user.

## Root cause

- Write path (`admin.routes.ts`, env-var seeding) stored the username with only `.trim()`.
- Read path (`auth.routes.ts` OAuth callback) looked up `user.login` with byte-exact equality via Drizzle's `eq()`.
- Therefore `Ye-Kart` ≠ `ye-kart` at the DB layer → `403 User not authorized` → bounce to login.

## What changed

**Defense in depth** — normalize on both sides plus a one-time data migration:

- **New util** `normalizeUsername(value)` in `@planner/core` — `trim()` + strip leading `@` + `toLowerCase()`. Exported from the package barrel.
- **Write path**:
  - `admin.routes.ts` — normalize on `POST /admin/allowed-users`.
  - `migrate.ts` — normalize `PLANNER_ALLOWED_GITHUB_USERS` and `PLANNER_ALLOWED_GOOGLE_EMAILS` during seed.
- **Read path**:
  - `auth.routes.ts` — normalize `user.login` / `user.email` before the allowlist check **and** before session creation, so session userIds are canonical going forward.
  - `admin.routes.ts` — normalize the username parsed from `session.userId` in the admin guard.
  - `auth.routes.ts` `/me` — normalize before the `isAdmin` lookup.
- **Data migration** — `normalizeAllowedUsers(db)` runs inside `runMigrations()`. Idempotent: `UPDATE ... WHERE username != LOWER(TRIM(username))` and `SUBSTR(username, 2) WHERE username LIKE '@%'`. Fixes existing rows on the first deploy.

## Why the data migration

Without it, the one live user already stored with non-canonical casing would *still* fail to log in after deploy — you'd have to manually re-add them via admin. The migration makes the fix self-healing.

## Why sessions keep working

Existing sessions store `github:OriginalCase`. The admin guard and `/me` now normalize *before* calling `isAdmin`, and the migration lowercases the DB side, so the comparison lines up without forcing re-login.

## Notes for reviewers

- Google emails are lowercased too. RFC 5321 says local-parts are case-sensitive, but every major provider treats them case-insensitively — matches user expectations and is consistent with the GitHub handling.
- The `normalizeAllowedUsers` migration is safe to leave in the startup path indefinitely (idempotent, runs in microseconds).
- No unique constraint on `allowed_users.username`, so the migration can't fail on collisions. If any exist after lowercasing, both rows survive and `findByProviderAndUsername` just picks one — still correctly `isAllowed = true`.

## Test plan

- [x] `pnpm --filter @planner/core lint` passes
- [x] `pnpm --filter @planner/api lint` passes
- [x] `npx vitest run tests/unit tests/integration/api` → **87/87 pass**
- [x] New unit tests in `tests/unit/identity.test.ts` cover casing, `@` prefix, whitespace, email, idempotence (6 cases)
- [x] Pre-existing E2E/habit failures verified unchanged on `main` baseline (not regressions from this PR)
- [ ] After deploy: verify the previously-added GitHub user can log in