### PR TITLE
⬆️ Bump actions/checkout to v6 (Node.js 24)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     concurrency: deploy
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 


### PR DESCRIPTION
## Summary

Silences the Node.js 20 deprecation warning that appears on every `Deploy` run.

`actions/checkout@v4` still declares `using: node20` in its `action.yml`. GitHub will force-remove Node.js 20 from runners on **2026-09-16** and force actions to Node.js 24 by default starting **2026-06-02**. `v6.0.2` (2026-01-09) declares `using: node24`, which removes the warning and avoids the forced-migration cliff.

## What changed

- `.github/workflows/deploy.yml` — bump `actions/checkout@v4` → `@v6`.

## Why v6 and not v5

Both v5 and v6 ship `node24`. v6 is the current stable line (v6.0.2 is the latest release as of 2026-01-09) and jumping straight to it avoids a second bump in a few months. There are no breaking input changes relevant to this workflow — we pass no inputs to `checkout`.

## Not fixed in this PR (intentional)

- `superfly/flyctl-actions/setup-flyctl@master` is pinned to a mutable branch. It's a separate, independent concern (supply-chain / reproducibility), not the Node.js deprecation the warning flagged. Happy to do a follow-up PR to pin it to a release tag.

## Test plan

- [ ] After merge: the next push to `main` runs `Deploy` without the Node.js 20 deprecation warning under *Annotations*.