### PR TITLE
:sparkles: Add 7-day free trial for AI features

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,17 @@ Supported file types: `.md`, `.txt`, `.json`, `.csv`, `.yaml`, `.yml`
 
 Works with any OpenAI-compatible API, including Ollama — see [Configuration](#configuration) for env vars.
 
+#### Free trial & subscriptions (web app)
+
+New users get **7 days of free AI access** on their first login. When the trial runs out, AI chat returns `402 Payment Required` and the UI prompts the user to subscribe. Planned pricing: **€1/month** or **€10/year** for unlimited AI usage. Admins (users marked `is_admin=1` in `allowed_users`) always bypass the gate.
+
+Endpoints:
+
+- `GET /api/auth/me` — includes `trial` state (`trial` / `trial_expired` / `active` / `admin`) and days remaining
+- `GET /api/auth/trial` — standalone trial status
+
+Payment processing is not yet wired up — the trial ships first so the full login→use→paywall flow can be exercised end-to-end before money moves.
+
 ## JSON output
 
 Every command (except `context`, which is always JSON) supports `--json`:

--- a/packages/api/src/container.ts
+++ b/packages/api/src/container.ts
@@ -1,9 +1,19 @@
 import { createAiContainer, createAiContainerWith, type AiContainer } from '@planner/ai';
-import { SessionRepository, AllowedUserRepository, SpaceRepository, SpaceService, type DB } from '@planner/core';
+import {
+  SessionRepository,
+  AllowedUserRepository,
+  SpaceRepository,
+  SpaceService,
+  UserTrialRepository,
+  TrialService,
+  type DB,
+} from '@planner/core';
 
 export interface ApiContainer extends AiContainer {
   sessionRepo: SessionRepository;
   allowedUserRepo: AllowedUserRepository;
+  userTrialRepo: UserTrialRepository;
+  trialService: TrialService;
   spaceService: SpaceService;
 }
 
@@ -16,8 +26,10 @@ export function createApiContainerForSpace(db: DB, spaceId: string): ApiContaine
   const ai = createAiContainerWith(db, spaceId);
   const sessionRepo = new SessionRepository(db);
   const allowedUserRepo = new AllowedUserRepository(db);
+  const userTrialRepo = new UserTrialRepository(db);
+  const trialService = new TrialService(userTrialRepo, allowedUserRepo);
   const spaceRepo = new SpaceRepository(db);
   const spaceService = new SpaceService(spaceRepo);
 
-  return { ...ai, sessionRepo, allowedUserRepo, spaceService };
+  return { ...ai, sessionRepo, allowedUserRepo, userTrialRepo, trialService, spaceService };
 }

--- a/packages/api/src/routes/auth.routes.ts
+++ b/packages/api/src/routes/auth.routes.ts
@@ -4,7 +4,7 @@ import type { ApiContainer } from '../container.js';
 
 export function createAuthRoutes(container: ApiContainer): Hono {
   const app = new Hono();
-  const { sessionRepo, allowedUserRepo } = container;
+  const { sessionRepo, allowedUserRepo, trialService } = container;
 
   const githubClientId = process.env.PLANNER_GITHUB_CLIENT_ID;
   const githubClientSecret = process.env.PLANNER_GITHUB_CLIENT_SECRET;
@@ -58,8 +58,11 @@ export function createAuthRoutes(container: ApiContainer): Hono {
       return c.json({ error: 'User not authorized' }, 403);
     }
 
+    const userId = `github:${login}`;
+    trialService.ensureTrial(userId);
+
     // Create session
-    const session = createSession(sessionRepo, `github:${login}`);
+    const session = createSession(sessionRepo, userId);
     const secure = c.req.header('x-forwarded-proto') === 'https' ? '; Secure' : '';
     c.header('Set-Cookie', `session=${session.id}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${30 * 24 * 60 * 60}${secure}`);
     return c.redirect('/');
@@ -126,8 +129,11 @@ export function createAuthRoutes(container: ApiContainer): Hono {
       return c.json({ error: 'User not authorized' }, 403);
     }
 
+    const userId = `google:${email}`;
+    trialService.ensureTrial(userId);
+
     // Create session
-    const session = createSession(sessionRepo, `google:${email}`);
+    const session = createSession(sessionRepo, userId);
     const secure = c.req.header('x-forwarded-proto') === 'https' ? '; Secure' : '';
     c.header('Set-Cookie', `session=${session.id}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${30 * 24 * 60 * 60}${secure}`);
     return c.redirect('/');
@@ -160,7 +166,23 @@ export function createAuthRoutes(container: ApiContainer): Hono {
     }
     const [provider, username] = session.userId.split(':');
     const isAdmin = provider && username ? allowedUserRepo.isAdmin(provider, normalizeUsername(username)) : false;
-    return c.json({ authenticated: true, userId: session.userId, isAdmin });
+
+    // Self-heal: if a legacy session pre-dates the trial table, create one now.
+    trialService.ensureTrial(session.userId);
+    const trial = trialService.getStatus(session.userId);
+
+    return c.json({ authenticated: true, userId: session.userId, isAdmin, trial });
+  });
+
+  app.get('/trial', (c) => {
+    const sessionId = getCookie(c, 'session');
+    if (!sessionId) return c.json({ error: 'Unauthorized' }, 401);
+    const session = sessionRepo.findById(sessionId);
+    if (!session || new Date(session.expiresAt) < new Date()) {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+    trialService.ensureTrial(session.userId);
+    return c.json(trialService.getStatus(session.userId));
   });
 
   return app;

--- a/packages/api/src/routes/chat.routes.ts
+++ b/packages/api/src/routes/chat.routes.ts
@@ -9,8 +9,13 @@ export function createChatRoutes(getContainer: ContainerGetter): Hono {
   const app = new Hono();
 
   app.get('/configured', (c) => {
-    const { chatService } = getContainer(c);
-    return c.json({ configured: chatService.isConfigured() });
+    const { chatService, trialService } = getContainer(c);
+    const userId = (c as { get: (key: string) => unknown }).get('userId') as string | undefined;
+    const trial = userId ? trialService.getStatus(userId) : null;
+    return c.json({
+      configured: chatService.isConfigured(),
+      trial,
+    });
   });
 
   app.get('/conversations', (c) => {
@@ -45,7 +50,20 @@ export function createChatRoutes(getContainer: ContainerGetter): Hono {
   });
 
   app.post('/conversations/:id/messages', (c) => {
-    const { chatService } = getContainer(c);
+    const { chatService, trialService } = getContainer(c);
+    const userId = (c as { get: (key: string) => unknown }).get('userId') as string | undefined;
+    if (userId) {
+      const status = trialService.getStatus(userId);
+      if (!status.hasAiAccess) {
+        return c.json(
+          {
+            error: 'Trial expired. Please subscribe to continue using AI features.',
+            trial: status,
+          },
+          402
+        );
+      }
+    }
     return streamSSE(c, async (stream) => {
       let body: { message: string; currentScreen?: string };
       try {

--- a/packages/core/src/db/migrate.ts
+++ b/packages/core/src/db/migrate.ts
@@ -101,6 +101,16 @@ const STATEMENTS = [
     is_admin INTEGER NOT NULL DEFAULT 0,
     created_at TEXT NOT NULL
   )`,
+  `CREATE TABLE IF NOT EXISTS user_trials (
+    user_id TEXT PRIMARY KEY,
+    trial_started_at TEXT NOT NULL,
+    trial_expires_at TEXT NOT NULL,
+    subscription_status TEXT NOT NULL DEFAULT 'trial' CHECK(subscription_status IN ('trial', 'active', 'expired', 'cancelled')),
+    plan TEXT CHECK(plan IN ('monthly', 'yearly')),
+    subscription_expires_at TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+  )`,
 ];
 
 // ALTER statements for migrating existing databases that lack the space_id column.

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -107,6 +107,19 @@ export const allowedUsers = sqliteTable('allowed_users', {
   createdAt: text('created_at').notNull(),
 });
 
+export const userTrials = sqliteTable('user_trials', {
+  userId: text('user_id').primaryKey(),
+  trialStartedAt: text('trial_started_at').notNull(),
+  trialExpiresAt: text('trial_expires_at').notNull(),
+  subscriptionStatus: text('subscription_status', {
+    enum: ['trial', 'active', 'expired', 'cancelled'],
+  }).notNull().default('trial'),
+  plan: text('plan', { enum: ['monthly', 'yearly'] }),
+  subscriptionExpiresAt: text('subscription_expires_at'),
+  createdAt: text('created_at').notNull(),
+  updatedAt: text('updated_at').notNull(),
+});
+
 // Type exports
 export type Space = typeof spaces.$inferSelect;
 export type NewSpace = typeof spaces.$inferInsert;
@@ -130,3 +143,5 @@ export type Session = typeof sessions.$inferSelect;
 export type NewSession = typeof sessions.$inferInsert;
 export type AllowedUser = typeof allowedUsers.$inferSelect;
 export type NewAllowedUser = typeof allowedUsers.$inferInsert;
+export type UserTrial = typeof userTrials.$inferSelect;
+export type NewUserTrial = typeof userTrials.$inferInsert;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ export type {
   Message, NewMessage,
   Session, NewSession,
   AllowedUser, NewAllowedUser,
+  UserTrial, NewUserTrial,
 } from './db/schema.js';
 
 // Repositories
@@ -31,6 +32,7 @@ export { ConversationRepository } from './repositories/conversation.repository.j
 export { MessageRepository } from './repositories/message.repository.js';
 export { SessionRepository } from './repositories/session.repository.js';
 export { AllowedUserRepository } from './repositories/allowed-user.repository.js';
+export { UserTrialRepository } from './repositories/user-trial.repository.js';
 
 // Services
 export { SpaceService } from './services/space.service.js';
@@ -43,6 +45,7 @@ export { StatusService, type StatusData } from './services/status.service.js';
 export { ConfigService, type ChatConfig } from './services/config.service.js';
 export { ExportService } from './services/export.service.js';
 export { InitService } from './services/init.service.js';
+export { TrialService, TRIAL_DURATION_DAYS, type TrialStatus, type TrialStatusState } from './services/trial.service.js';
 export { calculateStreaks, type StreakResult } from './services/streak.js';
 
 // Container

--- a/packages/core/src/repositories/user-trial.repository.ts
+++ b/packages/core/src/repositories/user-trial.repository.ts
@@ -1,0 +1,21 @@
+import { eq } from 'drizzle-orm';
+import { userTrials, type UserTrial, type NewUserTrial } from '../db/schema.js';
+import type { DB } from '../db/connection.js';
+
+export class UserTrialRepository {
+  constructor(private db: DB) {}
+
+  findByUserId(userId: string): UserTrial | undefined {
+    return this.db.select().from(userTrials).where(eq(userTrials.userId, userId)).get();
+  }
+
+  create(data: NewUserTrial): UserTrial {
+    this.db.insert(userTrials).values(data).run();
+    return this.findByUserId(data.userId)!;
+  }
+
+  update(userId: string, data: Partial<Omit<NewUserTrial, 'userId' | 'createdAt'>>): UserTrial | undefined {
+    this.db.update(userTrials).set(data).where(eq(userTrials.userId, userId)).run();
+    return this.findByUserId(userId);
+  }
+}

--- a/packages/core/src/services/trial.service.ts
+++ b/packages/core/src/services/trial.service.ts
@@ -1,0 +1,115 @@
+import type { UserTrialRepository } from '../repositories/user-trial.repository.js';
+import type { AllowedUserRepository } from '../repositories/allowed-user.repository.js';
+import { normalizeUsername } from '../utils/identity.js';
+
+export const TRIAL_DURATION_DAYS = 7;
+
+export type TrialStatusState =
+  | 'trial'
+  | 'trial_expired'
+  | 'active'
+  | 'admin';
+
+export interface TrialStatus {
+  state: TrialStatusState;
+  trialStartedAt: string | null;
+  trialExpiresAt: string | null;
+  subscriptionExpiresAt: string | null;
+  plan: 'monthly' | 'yearly' | null;
+  daysRemaining: number;
+  hasAiAccess: boolean;
+}
+
+export class TrialService {
+  constructor(
+    private trialRepo: UserTrialRepository,
+    private allowedUserRepo: AllowedUserRepository
+  ) {}
+
+  // Idempotent: creates the trial record on first call, returns existing one otherwise.
+  ensureTrial(userId: string, now: Date = new Date()): void {
+    const existing = this.trialRepo.findByUserId(userId);
+    if (existing) return;
+
+    const nowIso = now.toISOString();
+    const expires = new Date(now.getTime() + TRIAL_DURATION_DAYS * 24 * 60 * 60 * 1000);
+
+    this.trialRepo.create({
+      userId,
+      trialStartedAt: nowIso,
+      trialExpiresAt: expires.toISOString(),
+      subscriptionStatus: 'trial',
+      plan: null,
+      subscriptionExpiresAt: null,
+      createdAt: nowIso,
+      updatedAt: nowIso,
+    });
+  }
+
+  getStatus(userId: string, now: Date = new Date()): TrialStatus {
+    if (this.isAdmin(userId)) {
+      return {
+        state: 'admin',
+        trialStartedAt: null,
+        trialExpiresAt: null,
+        subscriptionExpiresAt: null,
+        plan: null,
+        daysRemaining: Number.POSITIVE_INFINITY,
+        hasAiAccess: true,
+      };
+    }
+
+    const trial = this.trialRepo.findByUserId(userId);
+    if (!trial) {
+      return {
+        state: 'trial_expired',
+        trialStartedAt: null,
+        trialExpiresAt: null,
+        subscriptionExpiresAt: null,
+        plan: null,
+        daysRemaining: 0,
+        hasAiAccess: false,
+      };
+    }
+
+    // Active paid subscription takes precedence
+    if (trial.subscriptionStatus === 'active' && trial.subscriptionExpiresAt) {
+      const subExpires = new Date(trial.subscriptionExpiresAt);
+      if (subExpires > now) {
+        return {
+          state: 'active',
+          trialStartedAt: trial.trialStartedAt,
+          trialExpiresAt: trial.trialExpiresAt,
+          subscriptionExpiresAt: trial.subscriptionExpiresAt,
+          plan: trial.plan ?? null,
+          daysRemaining: daysBetween(now, subExpires),
+          hasAiAccess: true,
+        };
+      }
+    }
+
+    const trialExpires = new Date(trial.trialExpiresAt);
+    const inTrial = trialExpires > now;
+
+    return {
+      state: inTrial ? 'trial' : 'trial_expired',
+      trialStartedAt: trial.trialStartedAt,
+      trialExpiresAt: trial.trialExpiresAt,
+      subscriptionExpiresAt: trial.subscriptionExpiresAt,
+      plan: trial.plan ?? null,
+      daysRemaining: inTrial ? daysBetween(now, trialExpires) : 0,
+      hasAiAccess: inTrial,
+    };
+  }
+
+  private isAdmin(userId: string): boolean {
+    const [provider, username] = userId.split(':');
+    if (!provider || !username) return false;
+    return this.allowedUserRepo.isAdmin(provider, normalizeUsername(username));
+  }
+}
+
+function daysBetween(from: Date, to: Date): number {
+  const ms = to.getTime() - from.getTime();
+  return Math.max(0, Math.ceil(ms / (1000 * 60 * 60 * 24)));
+}

--- a/packages/web/src/api/auth.api.ts
+++ b/packages/web/src/api/auth.api.ts
@@ -1,0 +1,7 @@
+import { api } from './client';
+import type { AuthMe, TrialStatus } from './types';
+
+export const authApi = {
+  me: () => api.get<AuthMe>('/api/auth/me'),
+  trial: () => api.get<TrialStatus>('/api/auth/trial'),
+};

--- a/packages/web/src/api/chat.api.ts
+++ b/packages/web/src/api/chat.api.ts
@@ -31,6 +31,11 @@ export const chatApi = {
       body: JSON.stringify({ message, currentScreen }),
       signal: controller.signal,
     }).then(async (res) => {
+      if (res.status === 402) {
+        const body = await res.json().catch(() => ({ error: 'Trial expired. Please subscribe to continue.' }));
+        callbacks.onError(body.error ?? 'Trial expired. Please subscribe to continue.');
+        return;
+      }
       if (!res.ok || !res.body) {
         callbacks.onError('Failed to connect to chat');
         return;

--- a/packages/web/src/api/types.ts
+++ b/packages/web/src/api/types.ts
@@ -113,3 +113,22 @@ export interface Message {
   createdAt: string;
   position: number;
 }
+
+export type TrialStatusState = 'trial' | 'trial_expired' | 'active' | 'admin';
+
+export interface TrialStatus {
+  state: TrialStatusState;
+  trialStartedAt: string | null;
+  trialExpiresAt: string | null;
+  subscriptionExpiresAt: string | null;
+  plan: 'monthly' | 'yearly' | null;
+  daysRemaining: number;
+  hasAiAccess: boolean;
+}
+
+export interface AuthMe {
+  authenticated: boolean;
+  userId?: string;
+  isAdmin?: boolean;
+  trial?: TrialStatus;
+}

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -11,6 +11,7 @@ import { HabitsPage } from './pages/habits';
 import { LoginPage } from './pages/login';
 import { SpacesPage } from './pages/spaces';
 import { AdminPage } from './pages/admin';
+import { SubscribePage } from './pages/subscribe';
 import { useKeyboard } from './hooks/use-keyboard';
 
 const queryClient = new QueryClient({
@@ -32,6 +33,7 @@ export function App() {
           <Route path="/login" element={<LoginPage />} />
           <Route path="/spaces/manage" element={<SpacesPage />} />
           <Route path="/admin" element={<AdminPage />} />
+          <Route path="/subscribe" element={<SubscribePage />} />
           <Route path="/" element={<SpaceRedirect />} />
           <Route path="/spaces/:spaceId" element={<SpaceProvider><KeyboardProvider><AppLayout /></KeyboardProvider></SpaceProvider>}>
             <Route index element={<DashboardPage />} />

--- a/packages/web/src/components/layout/app-layout.tsx
+++ b/packages/web/src/components/layout/app-layout.tsx
@@ -4,6 +4,7 @@ import { Sidebar } from './sidebar';
 import { KeyboardHintBar } from './keyboard-hint-bar';
 import { ChatPanel } from '../chat/chat-panel';
 import { MobileHeader } from './mobile-header';
+import { TrialBanner } from './trial-banner';
 
 export function AppLayout() {
   const [chatOpen, setChatOpen] = useState(false);
@@ -35,6 +36,7 @@ export function AppLayout() {
         onMenuToggle={() => setSidebarOpen((prev) => !prev)}
         onChatToggle={() => setChatOpen((prev) => !prev)}
       />
+      <TrialBanner />
       <div className="flex-1 flex overflow-hidden">
         <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
         <main className="flex-1 overflow-auto p-4 md:p-6">

--- a/packages/web/src/components/layout/trial-banner.tsx
+++ b/packages/web/src/components/layout/trial-banner.tsx
@@ -1,0 +1,51 @@
+import { Link } from 'react-router-dom';
+import { useTrial } from '../../hooks/use-api';
+
+export function TrialBanner() {
+  const { data } = useTrial();
+  if (!data) return null;
+  if (data.state === 'admin' || data.state === 'active') return null;
+
+  if (data.state === 'trial_expired') {
+    return (
+      <div className="w-full bg-[var(--color-error)]/15 border-b border-[var(--color-error)]/40 text-[var(--color-text-primary)] px-4 py-2 flex items-center justify-between gap-3 text-sm">
+        <span>
+          Your free trial has ended. Subscribe to keep using AI features.
+        </span>
+        <Link
+          to="/subscribe"
+          className="px-3 py-1 rounded bg-[var(--color-accent-1)] text-[var(--color-bg)] font-medium hover:opacity-90"
+        >
+          Subscribe
+        </Link>
+      </div>
+    );
+  }
+
+  // state === 'trial'
+  const days = data.daysRemaining;
+  const low = days <= 2;
+  return (
+    <div
+      className={`w-full px-4 py-2 flex items-center justify-between gap-3 text-sm border-b ${
+        low
+          ? 'bg-[var(--color-warning)]/15 border-[var(--color-warning)]/40'
+          : 'bg-[var(--color-bg-highlight)] border-[var(--color-border)]'
+      } text-[var(--color-text-primary)]`}
+    >
+      <span>
+        Free trial:{' '}
+        <strong>
+          {days} day{days === 1 ? '' : 's'}
+        </strong>{' '}
+        remaining.
+      </span>
+      <Link
+        to="/subscribe"
+        className="px-3 py-1 rounded bg-[var(--color-accent-1)] text-[var(--color-bg)] font-medium hover:opacity-90"
+      >
+        Subscribe
+      </Link>
+    </div>
+  );
+}

--- a/packages/web/src/hooks/use-api.ts
+++ b/packages/web/src/hooks/use-api.ts
@@ -5,7 +5,17 @@ import { goalsApi } from '../api/goals.api';
 import { tasksApi } from '../api/tasks.api';
 import { habitsApi } from '../api/habits.api';
 import { statusApi } from '../api/status.api';
+import { authApi } from '../api/auth.api';
 import { useCurrentSpace } from '../contexts/space-context';
+
+// --- Auth / trial ---
+export function useAuthMe() {
+  return useQuery({ queryKey: ['auth', 'me'], queryFn: authApi.me, staleTime: 60_000 });
+}
+
+export function useTrial() {
+  return useQuery({ queryKey: ['auth', 'trial'], queryFn: authApi.trial, staleTime: 60_000 });
+}
 
 // --- Spaces (unscoped) ---
 export function useSpaces() {

--- a/packages/web/src/pages/subscribe.tsx
+++ b/packages/web/src/pages/subscribe.tsx
@@ -1,0 +1,105 @@
+import { Link } from 'react-router-dom';
+import { useTrial } from '../hooks/use-api';
+
+export function SubscribePage() {
+  const { data: trial } = useTrial();
+
+  return (
+    <div className="min-h-screen bg-[var(--color-bg)] text-[var(--color-text-primary)] px-4 py-10">
+      <div className="max-w-3xl mx-auto space-y-8">
+        <header className="space-y-2">
+          <Link
+            to="/"
+            className="text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text-accent)]"
+          >
+            ← Back
+          </Link>
+          <h1 className="text-3xl font-bold text-[var(--color-text-accent)]">
+            Keep using Planner AI
+          </h1>
+          <p className="text-[var(--color-text-secondary)]">
+            {trial?.state === 'trial_expired'
+              ? 'Your 7-day free trial has ended. Pick a plan to continue using the AI assistant.'
+              : trial?.state === 'active'
+                ? 'You have an active subscription. Thank you for supporting Planner!'
+                : `You're on the free trial — ${trial?.daysRemaining ?? 0} day${trial?.daysRemaining === 1 ? '' : 's'} left. You can subscribe any time.`}
+          </p>
+        </header>
+
+        <section className="grid gap-4 md:grid-cols-2">
+          <PlanCard
+            title="Monthly"
+            price="€1"
+            cadence="per month"
+            highlight={false}
+            description="Flexibility to cancel any time."
+          />
+          <PlanCard
+            title="Yearly"
+            price="€10"
+            cadence="per year"
+            highlight={true}
+            description="Save ~17% vs. monthly billing."
+          />
+        </section>
+
+        <section className="rounded border border-[var(--color-border)] bg-[var(--color-bg-panel)] p-4 text-sm text-[var(--color-text-secondary)]">
+          <p className="font-medium text-[var(--color-text-primary)] mb-1">
+            Payments coming soon
+          </p>
+          <p>
+            We&apos;re rolling out the trial first so you can try the AI
+            assistant end-to-end. Payment processing will be enabled shortly —
+            your access won&apos;t be interrupted during the switch-over.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+interface PlanCardProps {
+  title: string;
+  price: string;
+  cadence: string;
+  description: string;
+  highlight: boolean;
+}
+
+function PlanCard({ title, price, cadence, description, highlight }: PlanCardProps) {
+  return (
+    <div
+      className={`rounded border p-5 flex flex-col gap-3 ${
+        highlight
+          ? 'border-[var(--color-accent-1)] bg-[var(--color-bg-highlight)]'
+          : 'border-[var(--color-border)] bg-[var(--color-bg-panel)]'
+      }`}
+    >
+      <div className="flex items-baseline justify-between">
+        <h2 className="text-lg font-semibold text-[var(--color-text-primary)]">
+          {title}
+        </h2>
+        {highlight && (
+          <span className="text-xs uppercase tracking-wide text-[var(--color-accent-1)]">
+            Best value
+          </span>
+        )}
+      </div>
+      <div className="flex items-baseline gap-2">
+        <span className="text-4xl font-bold text-[var(--color-text-accent)]">
+          {price}
+        </span>
+        <span className="text-sm text-[var(--color-text-secondary)]">
+          {cadence}
+        </span>
+      </div>
+      <p className="text-sm text-[var(--color-text-secondary)]">{description}</p>
+      <button
+        disabled
+        className="mt-2 px-3 py-2 rounded bg-[var(--color-accent-1)] text-[var(--color-bg)] font-medium opacity-60 cursor-not-allowed"
+      >
+        Subscribe (coming soon)
+      </button>
+    </div>
+  );
+}

--- a/tests/integration/api/helpers.ts
+++ b/tests/integration/api/helpers.ts
@@ -4,14 +4,20 @@ import {
   SessionRepository,
   SpaceRepository,
   SpaceService,
+  AllowedUserRepository,
+  UserTrialRepository,
+  TrialService,
 } from '@planner/core';
-import { ChatService, type AiContainer } from '@planner/ai';
+import { ChatService } from '@planner/ai';
 import { createApp, type ApiContainer } from '@planner/api';
 import { createTestDb, createTestSpace } from '../helpers/db';
 
 export function createTestApiContainer(db: DB, spaceId: string): ApiContainer {
   const core = createTestContainer(db, spaceId);
   const sessionRepo = new SessionRepository(db);
+  const allowedUserRepo = new AllowedUserRepository(db);
+  const userTrialRepo = new UserTrialRepository(db);
+  const trialService = new TrialService(userTrialRepo, allowedUserRepo);
   const spaceRepo = new SpaceRepository(db);
   const spaceService = new SpaceService(spaceRepo);
 
@@ -20,7 +26,7 @@ export function createTestApiContainer(db: DB, spaceId: string): ApiContainer {
     core.areaService, core.goalService, core.taskService, core.habitService, core.contextService,
   );
 
-  return { ...core, chatService, sessionRepo, spaceService };
+  return { ...core, chatService, sessionRepo, allowedUserRepo, userTrialRepo, trialService, spaceService };
 }
 
 export function createTestApp() {

--- a/tests/integration/api/trial.test.ts
+++ b/tests/integration/api/trial.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createTestApp } from './helpers';
+import type { ApiContainer } from '@planner/api';
+
+let container: ApiContainer;
+
+beforeEach(() => {
+  ({ container } = createTestApp());
+});
+
+describe('Trial gating wiring', () => {
+  it('container exposes trialService', () => {
+    expect(container.trialService).toBeDefined();
+    expect(typeof container.trialService.ensureTrial).toBe('function');
+    expect(typeof container.trialService.getStatus).toBe('function');
+  });
+
+  it('ensureTrial + getStatus round-trip through the api container', () => {
+    container.trialService.ensureTrial('github:alice');
+    const status = container.trialService.getStatus('github:alice');
+    expect(status.state).toBe('trial');
+    expect(status.hasAiAccess).toBe(true);
+    expect(status.daysRemaining).toBeGreaterThan(0);
+    expect(status.daysRemaining).toBeLessThanOrEqual(7);
+  });
+
+  it('users without a trial row are treated as expired', () => {
+    const status = container.trialService.getStatus('github:ghost');
+    expect(status.state).toBe('trial_expired');
+    expect(status.hasAiAccess).toBe(false);
+  });
+});

--- a/tests/integration/trial.test.ts
+++ b/tests/integration/trial.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createTestDb } from './helpers/db.js';
+import {
+  UserTrialRepository,
+  AllowedUserRepository,
+  TrialService,
+  TRIAL_DURATION_DAYS,
+  generateId,
+  type DB,
+} from '@planner/core';
+
+let db: DB;
+let service: TrialService;
+let trialRepo: UserTrialRepository;
+let allowedUserRepo: AllowedUserRepository;
+
+beforeEach(() => {
+  db = createTestDb();
+  trialRepo = new UserTrialRepository(db);
+  allowedUserRepo = new AllowedUserRepository(db);
+  service = new TrialService(trialRepo, allowedUserRepo);
+});
+
+describe('TrialService', () => {
+  it('creates a trial record with 7-day window on first call', () => {
+    const now = new Date('2026-01-01T00:00:00Z');
+    service.ensureTrial('github:alice', now);
+
+    const row = trialRepo.findByUserId('github:alice');
+    expect(row).toBeDefined();
+    expect(row!.trialStartedAt).toBe(now.toISOString());
+    const expires = new Date(row!.trialExpiresAt).getTime() - now.getTime();
+    expect(expires).toBe(TRIAL_DURATION_DAYS * 24 * 60 * 60 * 1000);
+    expect(row!.subscriptionStatus).toBe('trial');
+  });
+
+  it('is idempotent — calling ensureTrial twice keeps the original start date', () => {
+    const first = new Date('2026-01-01T00:00:00Z');
+    const second = new Date('2026-01-05T00:00:00Z');
+    service.ensureTrial('github:alice', first);
+    service.ensureTrial('github:alice', second);
+
+    const row = trialRepo.findByUserId('github:alice')!;
+    expect(row.trialStartedAt).toBe(first.toISOString());
+  });
+
+  it('reports trial state with days remaining during the trial window', () => {
+    const start = new Date('2026-01-01T00:00:00Z');
+    service.ensureTrial('github:alice', start);
+
+    const day3 = new Date('2026-01-04T00:00:00Z');
+    const status = service.getStatus('github:alice', day3);
+    expect(status.state).toBe('trial');
+    expect(status.hasAiAccess).toBe(true);
+    expect(status.daysRemaining).toBe(4); // 7 - 3
+  });
+
+  it('reports trial_expired after 7 days and blocks AI access', () => {
+    const start = new Date('2026-01-01T00:00:00Z');
+    service.ensureTrial('github:alice', start);
+
+    const after = new Date('2026-01-10T00:00:00Z');
+    const status = service.getStatus('github:alice', after);
+    expect(status.state).toBe('trial_expired');
+    expect(status.hasAiAccess).toBe(false);
+    expect(status.daysRemaining).toBe(0);
+  });
+
+  it('treats users without a trial row as expired (defensive)', () => {
+    const status = service.getStatus('github:unknown');
+    expect(status.state).toBe('trial_expired');
+    expect(status.hasAiAccess).toBe(false);
+  });
+
+  it('bypasses the gate for admin users', () => {
+    allowedUserRepo.create({
+      id: generateId(),
+      provider: 'github',
+      username: 'root',
+      isAdmin: true,
+      createdAt: new Date().toISOString(),
+    });
+
+    const status = service.getStatus('github:root');
+    expect(status.state).toBe('admin');
+    expect(status.hasAiAccess).toBe(true);
+  });
+
+  it('grants access when an active subscription is present, even after trial expires', () => {
+    const start = new Date('2026-01-01T00:00:00Z');
+    service.ensureTrial('github:alice', start);
+
+    const subExpires = new Date('2026-03-01T00:00:00Z');
+    trialRepo.update('github:alice', {
+      subscriptionStatus: 'active',
+      plan: 'monthly',
+      subscriptionExpiresAt: subExpires.toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const after = new Date('2026-02-01T00:00:00Z'); // past trial, inside sub
+    const status = service.getStatus('github:alice', after);
+    expect(status.state).toBe('active');
+    expect(status.hasAiAccess).toBe(true);
+    expect(status.plan).toBe('monthly');
+  });
+
+  it('falls back to expired when subscription has itself lapsed', () => {
+    const start = new Date('2026-01-01T00:00:00Z');
+    service.ensureTrial('github:alice', start);
+
+    trialRepo.update('github:alice', {
+      subscriptionStatus: 'active',
+      plan: 'monthly',
+      subscriptionExpiresAt: '2026-01-20T00:00:00Z',
+      updatedAt: new Date().toISOString(),
+    });
+
+    const after = new Date('2026-02-01T00:00:00Z');
+    const status = service.getStatus('github:alice', after);
+    expect(status.state).toBe('trial_expired');
+    expect(status.hasAiAccess).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- New `user_trials` table + `TrialService`, populated on OAuth callback (GitHub + Google). Idempotent — subsequent logins don't reset the window.
- AI chat route returns `402 Payment Required` once the 7-day window elapses. Admins (`allowed_users.is_admin = 1`) always bypass.
- Trial status exposed via `/api/auth/me` and `/api/auth/trial`. Web app shows a top banner with days remaining + a `/subscribe` page listing the planned €1/month and €10/year plans. Actual payment flow is **not** wired up yet — that's the next PR.

## How it works
- On every successful OAuth login `trialService.ensureTrial(userId)` creates the row if missing; `trial_started_at` is fixed at first login.
- `getStatus` returns one of `trial` / `trial_expired` / `active` / `admin` and a `hasAiAccess` boolean. The chat route checks it before opening the SSE stream.
- When `hasAiAccess = false`, the web chat panel surfaces the 402 error and the banner links to `/subscribe`.

## Test plan
- [ ] After merge & deploy, visit the app as a fresh GitHub/Google user — banner reads "7 days remaining"
- [ ] Send an AI chat message — succeeds
- [ ] `GET /api/auth/me` returns `trial.state = 'trial'` with `daysRemaining` between 1 and 7
- [ ] As an admin user, banner is hidden and `trial.state = 'admin'`
- [ ] Manually expire a trial in the DB (`UPDATE user_trials SET trial_expires_at = '2020-01-01' WHERE user_id = '…'`) and confirm AI chat returns 402 + banner flips to red "Trial has ended"
- [ ] `/subscribe` page renders both plans with the correct prices

## Follow-ups
- Payment provider integration (Stripe / Paddle) and wiring the subscribe buttons
- Webhook handler to mark `subscription_status = 'active'` with `plan` + `subscription_expires_at`
- Admin UI to view/extend individual trials