### PR TITLE
:sparkles: Add Stripe billing: checkout, portal, webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,14 +366,31 @@ Works with any OpenAI-compatible API, including Ollama — see [Configuration](#
 
 #### Free trial & subscriptions (web app)
 
-New users get **7 days of free AI access** on their first login. When the trial runs out, AI chat returns `402 Payment Required` and the UI prompts the user to subscribe. Planned pricing: **€1/month** or **€10/year** for unlimited AI usage. Admins (users marked `is_admin=1` in `allowed_users`) always bypass the gate.
+New users get **7 days of free AI access** on their first login. When the trial runs out, AI chat returns `402 Payment Required` and the UI prompts the user to subscribe. Pricing: **€1/month** or **€10/year** for unlimited AI usage. Admins (users marked `is_admin=1` in `allowed_users`) always bypass the gate.
 
-Endpoints:
+**Endpoints:**
 
 - `GET /api/auth/me` — includes `trial` state (`trial` / `trial_expired` / `active` / `admin`) and days remaining
 - `GET /api/auth/trial` — standalone trial status
+- `POST /api/billing/checkout` — body `{ plan: 'monthly' | 'yearly' }` → `{ url }` (Stripe Checkout)
+- `POST /api/billing/portal` → `{ url }` (Stripe Customer Portal — cancel, update card)
+- `POST /api/billing/webhook` — Stripe event sink (verifies `stripe-signature`)
+- `GET  /api/billing/status` — `{ configured: boolean }`
+- `GET  /api/billing/self` — current user's subscription summary
 
-Payment processing is not yet wired up — the trial ships first so the full login→use→paywall flow can be exercised end-to-end before money moves.
+**Stripe setup:**
+
+1. In the [Stripe Dashboard](https://dashboard.stripe.com/) create one Product with two recurring Prices: €1/month and €10/year. Copy both `price_…` IDs.
+2. Set env vars: `PLANNER_STRIPE_SECRET_KEY`, `PLANNER_STRIPE_PRICE_MONTHLY`, `PLANNER_STRIPE_PRICE_YEARLY`.
+3. Add a Webhook endpoint pointing at `https://<your-host>/api/billing/webhook`, subscribed to:
+   - `checkout.session.completed`
+   - `customer.subscription.updated`
+   - `customer.subscription.deleted`
+   - `invoice.payment_failed`
+4. Copy the endpoint's signing secret (`whsec_…`) into `PLANNER_STRIPE_WEBHOOK_SECRET`.
+5. For local testing: `stripe login && stripe listen --forward-to localhost:3000/api/billing/webhook` — the CLI prints a `whsec_…` to use as your dev webhook secret.
+
+If any of the four Stripe env vars are missing, the billing service is disabled, `/subscribe` shows a "Payments not configured" banner, and the buttons are non-interactive. The trial gate still works without Stripe — it just can't be escaped via payment.
 
 ## JSON output
 
@@ -441,6 +458,10 @@ When `PLANNER_GITHUB_CLIENT_ID` is set, the web app requires GitHub OAuth login.
 | `PLANNER_GITHUB_CLIENT_ID` | — | GitHub OAuth app client ID (enables web auth) |
 | `PLANNER_GITHUB_CLIENT_SECRET` | — | GitHub OAuth app client secret |
 | `PLANNER_ALLOWED_GITHUB_USERS` | — | Comma-separated GitHub usernames allowed to log in |
+| `PLANNER_STRIPE_SECRET_KEY` | — | Stripe secret key (`sk_live_…` or `sk_test_…`) — enables billing |
+| `PLANNER_STRIPE_WEBHOOK_SECRET` | — | Stripe webhook endpoint signing secret (`whsec_…`) |
+| `PLANNER_STRIPE_PRICE_MONTHLY` | — | Stripe recurring **Price ID** for the €1/month plan |
+| `PLANNER_STRIPE_PRICE_YEARLY` | — | Stripe recurring **Price ID** for the €10/year plan |
 | `PORT` | `3000` | API server port |
 
 The database is a single SQLite file at `$PLANNER_HOME/planner.db`.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react": "^18.3.1",
     "drizzle-kit": "^0.30.4",
     "ink-testing-library": "^4.0.0",
+    "stripe": "^18.5.0",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
     "vitest": "^3.0.5"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -19,6 +19,7 @@
     "@planner/core": "workspace:*",
     "@planner/ai": "workspace:*",
     "hono": "^4.7.4",
-    "@hono/node-server": "^1.14.1"
+    "@hono/node-server": "^1.14.1",
+    "stripe": "^18.5.0"
   }
 }

--- a/packages/api/src/container.ts
+++ b/packages/api/src/container.ts
@@ -8,6 +8,7 @@ import {
   TrialService,
   type DB,
 } from '@planner/core';
+import { BillingService, readBillingConfig } from './services/billing.service.js';
 
 export interface ApiContainer extends AiContainer {
   sessionRepo: SessionRepository;
@@ -15,6 +16,7 @@ export interface ApiContainer extends AiContainer {
   userTrialRepo: UserTrialRepository;
   trialService: TrialService;
   spaceService: SpaceService;
+  billingService: BillingService | null;
 }
 
 export function createApiContainer(): ApiContainer {
@@ -31,5 +33,18 @@ export function createApiContainerForSpace(db: DB, spaceId: string): ApiContaine
   const spaceRepo = new SpaceRepository(db);
   const spaceService = new SpaceService(spaceRepo);
 
-  return { ...ai, sessionRepo, allowedUserRepo, userTrialRepo, trialService, spaceService };
+  const billingConfig = readBillingConfig();
+  const billingService = billingConfig
+    ? new BillingService(userTrialRepo, billingConfig)
+    : null;
+
+  return {
+    ...ai,
+    sessionRepo,
+    allowedUserRepo,
+    userTrialRepo,
+    trialService,
+    spaceService,
+    billingService,
+  };
 }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -14,6 +14,7 @@ import { createChatRoutes } from './routes/chat.routes.js';
 import { createAuthRoutes } from './routes/auth.routes.js';
 import { createSpacesRoutes } from './routes/spaces.routes.js';
 import { createAdminRoutes } from './routes/admin.routes.js';
+import { createBillingRoutes } from './routes/billing.routes.js';
 
 interface CreateAppOptions {
   container?: ApiContainer;
@@ -42,11 +43,18 @@ export function createApp(options?: CreateAppOptions) {
   const authContainer = createApiContainerForSpace(db, '__auth__');
   app.route('/api/auth', createAuthRoutes(authContainer));
 
+  // --- Billing routes — registered BEFORE auth middleware. The webhook is
+  // verified by Stripe signature; /checkout and /portal validate the session
+  // cookie themselves via a fallback in the handler. ---
+  const billingRoutes = createBillingRoutes(authContainer);
+  app.route('/api/billing', billingRoutes);
+
   // Auth middleware for all other API routes
   if (process.env.PLANNER_GITHUB_CLIENT_ID || process.env.PLANNER_GOOGLE_CLIENT_ID) {
     const authMiddleware = createAuthMiddleware(authContainer);
     app.use('/api/*', async (c, next) => {
       if (c.req.path.startsWith('/api/auth')) return next();
+      if (c.req.path.startsWith('/api/billing')) return next();
       return authMiddleware(c, next);
     });
   }
@@ -92,6 +100,7 @@ function createAppWithFixedContainer(app: Hono, container: ApiContainer, db: DB)
 }
 
 export { createApiContainer, createApiContainerForSpace, type ApiContainer } from './container.js';
+export { BillingService, readBillingConfig, type BillingConfig, type Plan } from './services/billing.service.js';
 export { createAreasRoutes } from './routes/areas.routes.js';
 export { createGoalsRoutes } from './routes/goals.routes.js';
 export { createTasksRoutes } from './routes/tasks.routes.js';

--- a/packages/api/src/routes/billing.routes.ts
+++ b/packages/api/src/routes/billing.routes.ts
@@ -1,0 +1,115 @@
+import { Hono } from 'hono';
+import type { ApiContainer } from '../container.js';
+
+export function createBillingRoutes(container: ApiContainer): Hono {
+  const app = new Hono();
+  const { billingService, sessionRepo, userTrialRepo } = container;
+
+  app.get('/status', (c) => {
+    return c.json({ configured: !!billingService });
+  });
+
+  // --- Webhook (no auth — signature-verified) ---
+  // Must run before any JSON body parsers; `c.req.text()` gives us the raw body.
+  app.post('/webhook', async (c) => {
+    if (!billingService) return c.json({ error: 'Billing not configured' }, 503);
+    const signature = c.req.header('stripe-signature') ?? null;
+    const body = await c.req.text();
+    try {
+      await billingService.handleWebhook(body, signature);
+      return c.json({ received: true });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Webhook error';
+      console.error('[stripe webhook]', msg);
+      return c.json({ error: msg }, 400);
+    }
+  });
+
+  // --- Auth'd endpoints ---
+  app.post('/checkout', async (c) => {
+    if (!billingService) return c.json({ error: 'Billing not configured' }, 503);
+    const userId = getUserId(c, sessionRepo);
+    if (!userId) return c.json({ error: 'Unauthorized' }, 401);
+
+    const body = await c.req.json<{ plan?: 'monthly' | 'yearly' }>().catch(
+      () => ({}) as { plan?: 'monthly' | 'yearly' }
+    );
+    const plan = body.plan;
+    if (plan !== 'monthly' && plan !== 'yearly') {
+      return c.json({ error: 'plan must be "monthly" or "yearly"' }, 400);
+    }
+
+    const baseUrl = getBaseUrl(c);
+    const email = extractEmail(userId);
+    try {
+      const { url } = await billingService.createCheckoutSession(userId, plan, baseUrl, email);
+      return c.json({ url });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Checkout failed';
+      return c.json({ error: msg }, 500);
+    }
+  });
+
+  app.post('/portal', async (c) => {
+    if (!billingService) return c.json({ error: 'Billing not configured' }, 503);
+    const userId = getUserId(c, sessionRepo);
+    if (!userId) return c.json({ error: 'Unauthorized' }, 401);
+
+    const baseUrl = getBaseUrl(c);
+    try {
+      const { url } = await billingService.createPortalSession(userId, baseUrl);
+      return c.json({ url });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Portal failed';
+      // Not-yet-subscribed is a 400, Stripe failures are 500.
+      const status = msg.includes('subscribe first') ? 400 : 500;
+      return c.json({ error: msg }, status);
+    }
+  });
+
+  // Internal lightweight status readback for the web UI (does the user have
+  // a subscription we'd want to expose a "Manage" button for?)
+  app.get('/self', (c) => {
+    const userId = getUserId(c, sessionRepo);
+    if (!userId) return c.json({ error: 'Unauthorized' }, 401);
+    const trial = userTrialRepo.findByUserId(userId);
+    return c.json({
+      hasStripeCustomer: !!trial?.stripeCustomerId,
+      subscriptionStatus: trial?.subscriptionStatus ?? null,
+      plan: trial?.plan ?? null,
+      subscriptionExpiresAt: trial?.subscriptionExpiresAt ?? null,
+    });
+  });
+
+  return app;
+}
+
+function getUserId(
+  c: { req: { header: (name: string) => string | undefined }; get: (key: string) => unknown },
+  sessionRepo: ApiContainer['sessionRepo']
+): string | null {
+  // Preferred: set by auth middleware upstream.
+  const viaCtx = (c as { get: (key: string) => unknown }).get('userId');
+  if (typeof viaCtx === 'string') return viaCtx;
+
+  // Fallback for deployments without auth middleware enabled (dev).
+  const cookie = c.req.header('cookie') ?? '';
+  const match = cookie.match(/(?:^|;\s*)session=([^;]*)/);
+  if (!match) return null;
+  const session = sessionRepo.findById(match[1]);
+  if (!session) return null;
+  if (new Date(session.expiresAt) < new Date()) return null;
+  return session.userId;
+}
+
+function getBaseUrl(c: { req: { header: (name: string) => string | undefined } }): string {
+  const proto = c.req.header('x-forwarded-proto') || 'http';
+  const host = c.req.header('host') || 'localhost';
+  return `${proto}://${host}`;
+}
+
+function extractEmail(userId: string): string | null {
+  const [provider, username] = userId.split(':');
+  if (provider === 'google' && username?.includes('@')) return username;
+  return null;
+}

--- a/packages/api/src/services/billing.service.ts
+++ b/packages/api/src/services/billing.service.ts
@@ -1,0 +1,200 @@
+import Stripe from 'stripe';
+import { ValidationError, type UserTrialRepository } from '@planner/core';
+
+export interface BillingConfig {
+  secretKey: string;
+  webhookSecret: string;
+  priceMonthly: string;
+  priceYearly: string;
+}
+
+export function readBillingConfig(): BillingConfig | null {
+  const secretKey = process.env.PLANNER_STRIPE_SECRET_KEY;
+  const webhookSecret = process.env.PLANNER_STRIPE_WEBHOOK_SECRET;
+  const priceMonthly = process.env.PLANNER_STRIPE_PRICE_MONTHLY;
+  const priceYearly = process.env.PLANNER_STRIPE_PRICE_YEARLY;
+  if (!secretKey || !webhookSecret || !priceMonthly || !priceYearly) {
+    return null;
+  }
+  return { secretKey, webhookSecret, priceMonthly, priceYearly };
+}
+
+export type Plan = 'monthly' | 'yearly';
+
+export class BillingService {
+  private stripe: Stripe;
+
+  constructor(
+    private trialRepo: UserTrialRepository,
+    private config: BillingConfig
+  ) {
+    this.stripe = new Stripe(config.secretKey);
+  }
+
+  isConfigured(): boolean {
+    return true;
+  }
+
+  async createCheckoutSession(
+    userId: string,
+    plan: Plan,
+    baseUrl: string,
+    email: string | null
+  ): Promise<{ url: string }> {
+    const price = plan === 'monthly' ? this.config.priceMonthly : this.config.priceYearly;
+    const customerId = await this.ensureCustomer(userId, email);
+
+    const session = await this.stripe.checkout.sessions.create({
+      mode: 'subscription',
+      customer: customerId,
+      line_items: [{ price, quantity: 1 }],
+      success_url: `${baseUrl}/subscribe/success?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${baseUrl}/subscribe`,
+      allow_promotion_codes: true,
+      client_reference_id: userId,
+      metadata: { userId, plan },
+    });
+
+    if (!session.url) {
+      throw new Error('Stripe did not return a checkout URL');
+    }
+    return { url: session.url };
+  }
+
+  async createPortalSession(userId: string, baseUrl: string): Promise<{ url: string }> {
+    const trial = this.trialRepo.findByUserId(userId);
+    if (!trial?.stripeCustomerId) {
+      throw new ValidationError('No Stripe customer — subscribe first before managing billing.');
+    }
+    const session = await this.stripe.billingPortal.sessions.create({
+      customer: trial.stripeCustomerId,
+      return_url: `${baseUrl}/subscribe`,
+    });
+    return { url: session.url };
+  }
+
+  // Verifies the signature, then dispatches to internal handlers.
+  async handleWebhook(rawBody: string, signature: string | null): Promise<void> {
+    if (!signature) throw new ValidationError('Missing stripe-signature header');
+    const event = this.stripe.webhooks.constructEvent(
+      rawBody,
+      signature,
+      this.config.webhookSecret
+    );
+
+    switch (event.type) {
+      case 'checkout.session.completed':
+        await this.onCheckoutCompleted(event.data.object as Stripe.Checkout.Session);
+        break;
+      case 'customer.subscription.updated':
+        await this.onSubscriptionUpdated(event.data.object as Stripe.Subscription);
+        break;
+      case 'customer.subscription.deleted':
+        await this.onSubscriptionDeleted(event.data.object as Stripe.Subscription);
+        break;
+      case 'invoice.payment_failed':
+        await this.onInvoicePaymentFailed(event.data.object as Stripe.Invoice);
+        break;
+      default:
+        // Ignore everything else — we don't need it for the trial gate.
+        break;
+    }
+  }
+
+  private async ensureCustomer(userId: string, email: string | null): Promise<string> {
+    const trial = this.trialRepo.findByUserId(userId);
+    if (trial?.stripeCustomerId) return trial.stripeCustomerId;
+
+    const customer = await this.stripe.customers.create({
+      email: email ?? undefined,
+      metadata: { userId },
+    });
+
+    this.trialRepo.update(userId, {
+      stripeCustomerId: customer.id,
+      updatedAt: new Date().toISOString(),
+    });
+    return customer.id;
+  }
+
+  private async onCheckoutCompleted(session: Stripe.Checkout.Session): Promise<void> {
+    const userId =
+      (session.metadata?.userId as string | undefined) ??
+      (session.client_reference_id as string | undefined);
+    if (!userId) return;
+    if (!session.subscription) return;
+
+    const subId =
+      typeof session.subscription === 'string' ? session.subscription : session.subscription.id;
+    const subscription = await this.stripe.subscriptions.retrieve(subId);
+    this.applySubscription(userId, subscription);
+  }
+
+  private async onSubscriptionUpdated(subscription: Stripe.Subscription): Promise<void> {
+    const userId = await this.resolveUserId(subscription.customer);
+    if (!userId) return;
+    this.applySubscription(userId, subscription);
+  }
+
+  private async onSubscriptionDeleted(subscription: Stripe.Subscription): Promise<void> {
+    const userId = await this.resolveUserId(subscription.customer);
+    if (!userId) return;
+    this.trialRepo.update(userId, {
+      subscriptionStatus: 'cancelled',
+      stripeSubscriptionId: subscription.id,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  private async onInvoicePaymentFailed(invoice: Stripe.Invoice): Promise<void> {
+    if (!invoice.customer) return;
+    const userId = await this.resolveUserId(invoice.customer);
+    if (!userId) return;
+    this.trialRepo.update(userId, {
+      subscriptionStatus: 'past_due',
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  private applySubscription(userId: string, subscription: Stripe.Subscription): void {
+    const item = subscription.items.data[0];
+    const priceId = item?.price.id ?? null;
+    const plan: Plan | null =
+      priceId === this.config.priceYearly
+        ? 'yearly'
+        : priceId === this.config.priceMonthly
+          ? 'monthly'
+          : null;
+
+    const periodEndSec = subscription.items.data[0]?.current_period_end ?? null;
+    const expiresAt = periodEndSec ? new Date(periodEndSec * 1000).toISOString() : null;
+
+    const status: 'active' | 'cancelled' | 'past_due' =
+      subscription.status === 'active' || subscription.status === 'trialing'
+        ? 'active'
+        : subscription.status === 'past_due'
+          ? 'past_due'
+          : 'cancelled';
+
+    this.trialRepo.update(userId, {
+      subscriptionStatus: status,
+      stripeSubscriptionId: subscription.id,
+      plan,
+      subscriptionExpiresAt: expiresAt,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  private async resolveUserId(
+    customer: string | Stripe.Customer | Stripe.DeletedCustomer
+  ): Promise<string | null> {
+    const customerId = typeof customer === 'string' ? customer : customer.id;
+    const trial = this.trialRepo.findByStripeCustomerId(customerId);
+    if (trial) return trial.userId;
+
+    // Fallback: read metadata off the Stripe customer
+    const fetched = await this.stripe.customers.retrieve(customerId);
+    if (fetched.deleted) return null;
+    return (fetched.metadata?.userId as string | undefined) ?? null;
+  }
+}

--- a/packages/core/src/db/migrate.ts
+++ b/packages/core/src/db/migrate.ts
@@ -105,9 +105,11 @@ const STATEMENTS = [
     user_id TEXT PRIMARY KEY,
     trial_started_at TEXT NOT NULL,
     trial_expires_at TEXT NOT NULL,
-    subscription_status TEXT NOT NULL DEFAULT 'trial' CHECK(subscription_status IN ('trial', 'active', 'expired', 'cancelled')),
+    subscription_status TEXT NOT NULL DEFAULT 'trial' CHECK(subscription_status IN ('trial', 'active', 'expired', 'cancelled', 'past_due')),
     plan TEXT CHECK(plan IN ('monthly', 'yearly')),
     subscription_expires_at TEXT,
+    stripe_customer_id TEXT,
+    stripe_subscription_id TEXT,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
   )`,
@@ -121,6 +123,8 @@ const ALTERS = [
   `ALTER TABLE tasks ADD COLUMN space_id TEXT REFERENCES spaces(id) ON DELETE CASCADE`,
   `ALTER TABLE habits ADD COLUMN space_id TEXT REFERENCES spaces(id) ON DELETE CASCADE`,
   `ALTER TABLE conversations ADD COLUMN space_id TEXT REFERENCES spaces(id) ON DELETE CASCADE`,
+  `ALTER TABLE user_trials ADD COLUMN stripe_customer_id TEXT`,
+  `ALTER TABLE user_trials ADD COLUMN stripe_subscription_id TEXT`,
 ];
 
 export function runMigrations(db: DB): void {

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -112,10 +112,12 @@ export const userTrials = sqliteTable('user_trials', {
   trialStartedAt: text('trial_started_at').notNull(),
   trialExpiresAt: text('trial_expires_at').notNull(),
   subscriptionStatus: text('subscription_status', {
-    enum: ['trial', 'active', 'expired', 'cancelled'],
+    enum: ['trial', 'active', 'expired', 'cancelled', 'past_due'],
   }).notNull().default('trial'),
   plan: text('plan', { enum: ['monthly', 'yearly'] }),
   subscriptionExpiresAt: text('subscription_expires_at'),
+  stripeCustomerId: text('stripe_customer_id'),
+  stripeSubscriptionId: text('stripe_subscription_id'),
   createdAt: text('created_at').notNull(),
   updatedAt: text('updated_at').notNull(),
 });

--- a/packages/core/src/repositories/user-trial.repository.ts
+++ b/packages/core/src/repositories/user-trial.repository.ts
@@ -9,6 +9,10 @@ export class UserTrialRepository {
     return this.db.select().from(userTrials).where(eq(userTrials.userId, userId)).get();
   }
 
+  findByStripeCustomerId(stripeCustomerId: string): UserTrial | undefined {
+    return this.db.select().from(userTrials).where(eq(userTrials.stripeCustomerId, stripeCustomerId)).get();
+  }
+
   create(data: NewUserTrial): UserTrial {
     this.db.insert(userTrials).values(data).run();
     return this.findByUserId(data.userId)!;

--- a/packages/web/src/api/billing.api.ts
+++ b/packages/web/src/api/billing.api.ts
@@ -1,0 +1,20 @@
+import { api } from './client';
+
+export interface BillingStatus {
+  configured: boolean;
+}
+
+export interface BillingSelf {
+  hasStripeCustomer: boolean;
+  subscriptionStatus: 'trial' | 'active' | 'expired' | 'cancelled' | 'past_due' | null;
+  plan: 'monthly' | 'yearly' | null;
+  subscriptionExpiresAt: string | null;
+}
+
+export const billingApi = {
+  status: () => api.get<BillingStatus>('/api/billing/status'),
+  self: () => api.get<BillingSelf>('/api/billing/self'),
+  checkout: (plan: 'monthly' | 'yearly') =>
+    api.post<{ url: string }>('/api/billing/checkout', { plan }),
+  portal: () => api.post<{ url: string }>('/api/billing/portal'),
+};

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -12,6 +12,7 @@ import { LoginPage } from './pages/login';
 import { SpacesPage } from './pages/spaces';
 import { AdminPage } from './pages/admin';
 import { SubscribePage } from './pages/subscribe';
+import { SubscribeSuccessPage } from './pages/subscribe-success';
 import { useKeyboard } from './hooks/use-keyboard';
 
 const queryClient = new QueryClient({
@@ -34,6 +35,7 @@ export function App() {
           <Route path="/spaces/manage" element={<SpacesPage />} />
           <Route path="/admin" element={<AdminPage />} />
           <Route path="/subscribe" element={<SubscribePage />} />
+          <Route path="/subscribe/success" element={<SubscribeSuccessPage />} />
           <Route path="/" element={<SpaceRedirect />} />
           <Route path="/spaces/:spaceId" element={<SpaceProvider><KeyboardProvider><AppLayout /></KeyboardProvider></SpaceProvider>}>
             <Route index element={<DashboardPage />} />

--- a/packages/web/src/hooks/use-api.ts
+++ b/packages/web/src/hooks/use-api.ts
@@ -6,6 +6,7 @@ import { tasksApi } from '../api/tasks.api';
 import { habitsApi } from '../api/habits.api';
 import { statusApi } from '../api/status.api';
 import { authApi } from '../api/auth.api';
+import { billingApi } from '../api/billing.api';
 import { useCurrentSpace } from '../contexts/space-context';
 
 // --- Auth / trial ---
@@ -15,6 +16,33 @@ export function useAuthMe() {
 
 export function useTrial() {
   return useQuery({ queryKey: ['auth', 'trial'], queryFn: authApi.trial, staleTime: 60_000 });
+}
+
+// --- Billing ---
+export function useBillingStatus() {
+  return useQuery({ queryKey: ['billing', 'status'], queryFn: billingApi.status, staleTime: 5 * 60_000 });
+}
+
+export function useBillingSelf() {
+  return useQuery({ queryKey: ['billing', 'self'], queryFn: billingApi.self, staleTime: 30_000 });
+}
+
+export function useStartCheckout() {
+  return useMutation({
+    mutationFn: billingApi.checkout,
+    onSuccess: ({ url }) => {
+      window.location.href = url;
+    },
+  });
+}
+
+export function useOpenPortal() {
+  return useMutation({
+    mutationFn: billingApi.portal,
+    onSuccess: ({ url }) => {
+      window.location.href = url;
+    },
+  });
 }
 
 // --- Spaces (unscoped) ---

--- a/packages/web/src/pages/subscribe-success.tsx
+++ b/packages/web/src/pages/subscribe-success.tsx
@@ -1,0 +1,56 @@
+import { useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+import { useTrial, useBillingSelf } from '../hooks/use-api';
+
+export function SubscribeSuccessPage() {
+  const qc = useQueryClient();
+  const { data: trial } = useTrial();
+  const { data: self } = useBillingSelf();
+
+  // Stripe fires the webhook asynchronously — poll the trial endpoint briefly
+  // so the UI flips from "trial" → "active" once the server catches up.
+  useEffect(() => {
+    let tries = 0;
+    const maxTries = 6; // ~12s
+    const interval = setInterval(() => {
+      tries += 1;
+      qc.invalidateQueries({ queryKey: ['auth', 'trial'] });
+      qc.invalidateQueries({ queryKey: ['auth', 'me'] });
+      qc.invalidateQueries({ queryKey: ['billing', 'self'] });
+      if (tries >= maxTries) clearInterval(interval);
+    }, 2000);
+    return () => clearInterval(interval);
+  }, [qc]);
+
+  const isActive = trial?.state === 'active' || self?.subscriptionStatus === 'active';
+
+  return (
+    <div className="min-h-screen bg-[var(--color-bg)] text-[var(--color-text-primary)] px-4 py-10">
+      <div className="max-w-xl mx-auto text-center space-y-6">
+        <h1 className="text-3xl font-bold text-[var(--color-text-accent)]">
+          {isActive ? 'You are subscribed' : 'Finalizing your subscription…'}
+        </h1>
+        <p className="text-[var(--color-text-secondary)]">
+          {isActive
+            ? 'AI features are unlocked. Thanks for supporting Planner!'
+            : 'Stripe is confirming your payment. This page will update in a few seconds.'}
+        </p>
+        <div className="flex items-center justify-center gap-3">
+          <Link
+            to="/"
+            className="px-4 py-2 rounded bg-[var(--color-accent-1)] text-[var(--color-bg)] font-medium hover:opacity-90"
+          >
+            Back to planner
+          </Link>
+          <Link
+            to="/subscribe"
+            className="px-4 py-2 rounded border border-[var(--color-border)] hover:border-[var(--color-border-active)]"
+          >
+            Manage subscription
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/pages/subscribe.tsx
+++ b/packages/web/src/pages/subscribe.tsx
@@ -1,8 +1,22 @@
 import { Link } from 'react-router-dom';
-import { useTrial } from '../hooks/use-api';
+import {
+  useTrial,
+  useBillingStatus,
+  useBillingSelf,
+  useStartCheckout,
+  useOpenPortal,
+} from '../hooks/use-api';
 
 export function SubscribePage() {
   const { data: trial } = useTrial();
+  const { data: billing } = useBillingStatus();
+  const { data: self } = useBillingSelf();
+  const checkout = useStartCheckout();
+  const portal = useOpenPortal();
+
+  const billingConfigured = !!billing?.configured;
+  const hasActiveSub = self?.subscriptionStatus === 'active';
+  const busy = checkout.isPending || portal.isPending;
 
   return (
     <div className="min-h-screen bg-[var(--color-bg)] text-[var(--color-text-primary)] px-4 py-10">
@@ -18,13 +32,33 @@ export function SubscribePage() {
             Keep using Planner AI
           </h1>
           <p className="text-[var(--color-text-secondary)]">
-            {trial?.state === 'trial_expired'
-              ? 'Your 7-day free trial has ended. Pick a plan to continue using the AI assistant.'
-              : trial?.state === 'active'
-                ? 'You have an active subscription. Thank you for supporting Planner!'
-                : `You're on the free trial — ${trial?.daysRemaining ?? 0} day${trial?.daysRemaining === 1 ? '' : 's'} left. You can subscribe any time.`}
+            {headlineFor(trial?.state, trial?.daysRemaining ?? 0)}
           </p>
         </header>
+
+        {self?.hasStripeCustomer && (
+          <section className="rounded border border-[var(--color-border)] bg-[var(--color-bg-panel)] p-4 flex items-center justify-between gap-4">
+            <div className="text-sm">
+              <p className="font-medium text-[var(--color-text-primary)]">
+                Subscription: {self.subscriptionStatus ?? 'unknown'}
+                {self.plan ? ` · ${self.plan}` : ''}
+              </p>
+              {self.subscriptionExpiresAt && (
+                <p className="text-[var(--color-text-secondary)]">
+                  Renews / ends:{' '}
+                  {new Date(self.subscriptionExpiresAt).toLocaleDateString()}
+                </p>
+              )}
+            </div>
+            <button
+              onClick={() => portal.mutate()}
+              disabled={busy}
+              className="px-3 py-2 rounded border border-[var(--color-border)] hover:border-[var(--color-border-active)] text-sm disabled:opacity-50"
+            >
+              Manage subscription
+            </button>
+          </section>
+        )}
 
         <section className="grid gap-4 md:grid-cols-2">
           <PlanCard
@@ -33,6 +67,8 @@ export function SubscribePage() {
             cadence="per month"
             highlight={false}
             description="Flexibility to cancel any time."
+            disabled={!billingConfigured || hasActiveSub || busy}
+            onClick={() => checkout.mutate('monthly')}
           />
           <PlanCard
             title="Yearly"
@@ -40,22 +76,42 @@ export function SubscribePage() {
             cadence="per year"
             highlight={true}
             description="Save ~17% vs. monthly billing."
+            disabled={!billingConfigured || hasActiveSub || busy}
+            onClick={() => checkout.mutate('yearly')}
           />
         </section>
 
-        <section className="rounded border border-[var(--color-border)] bg-[var(--color-bg-panel)] p-4 text-sm text-[var(--color-text-secondary)]">
-          <p className="font-medium text-[var(--color-text-primary)] mb-1">
-            Payments coming soon
-          </p>
-          <p>
-            We&apos;re rolling out the trial first so you can try the AI
-            assistant end-to-end. Payment processing will be enabled shortly —
-            your access won&apos;t be interrupted during the switch-over.
-          </p>
-        </section>
+        {!billingConfigured && (
+          <section className="rounded border border-[var(--color-warning)]/40 bg-[var(--color-warning)]/10 p-4 text-sm text-[var(--color-text-primary)]">
+            <p className="font-medium mb-1">Payments not configured yet</p>
+            <p className="text-[var(--color-text-secondary)]">
+              Stripe env vars haven&apos;t been set on this deployment. Once an
+              admin adds them, the buttons above become live.
+            </p>
+          </section>
+        )}
+
+        {(checkout.isError || portal.isError) && (
+          <section className="rounded border border-[var(--color-error)]/40 bg-[var(--color-error)]/10 p-4 text-sm text-[var(--color-error)]">
+            {checkout.error instanceof Error
+              ? checkout.error.message
+              : portal.error instanceof Error
+                ? portal.error.message
+                : 'Something went wrong.'}
+          </section>
+        )}
       </div>
     </div>
   );
+}
+
+function headlineFor(state: string | undefined, days: number): string {
+  if (state === 'trial_expired')
+    return 'Your 7-day free trial has ended. Pick a plan to continue using the AI assistant.';
+  if (state === 'active')
+    return 'You have an active subscription. Thank you for supporting Planner!';
+  if (state === 'admin') return 'You are an admin — AI access is unlimited.';
+  return `You're on the free trial — ${days} day${days === 1 ? '' : 's'} left. You can subscribe any time.`;
 }
 
 interface PlanCardProps {
@@ -64,9 +120,19 @@ interface PlanCardProps {
   cadence: string;
   description: string;
   highlight: boolean;
+  disabled: boolean;
+  onClick: () => void;
 }
 
-function PlanCard({ title, price, cadence, description, highlight }: PlanCardProps) {
+function PlanCard({
+  title,
+  price,
+  cadence,
+  description,
+  highlight,
+  disabled,
+  onClick,
+}: PlanCardProps) {
   return (
     <div
       className={`rounded border p-5 flex flex-col gap-3 ${
@@ -95,10 +161,11 @@ function PlanCard({ title, price, cadence, description, highlight }: PlanCardPro
       </div>
       <p className="text-sm text-[var(--color-text-secondary)]">{description}</p>
       <button
-        disabled
-        className="mt-2 px-3 py-2 rounded bg-[var(--color-accent-1)] text-[var(--color-bg)] font-medium opacity-60 cursor-not-allowed"
+        onClick={onClick}
+        disabled={disabled}
+        className="mt-2 px-3 py-2 rounded bg-[var(--color-accent-1)] text-[var(--color-bg)] font-medium hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
       >
-        Subscribe (coming soon)
+        {disabled ? 'Unavailable' : 'Subscribe'}
       </button>
     </div>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       react:
         specifier: ^18.3.1
         version: 18.3.1
+      stripe:
+        specifier: ^18.5.0
+        version: 18.5.0(@types/node@22.19.11)
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -59,6 +62,9 @@ importers:
       hono:
         specifier: ^4.7.4
         version: 4.11.9
+      stripe:
+        specifier: ^18.5.0
+        version: 18.5.0(@types/node@22.19.11)
 
   packages/cli:
     dependencies:
@@ -1262,6 +1268,10 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
   caniuse-lite@1.0.30001770:
     resolution: {integrity: sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==}
 
@@ -2077,6 +2087,10 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -2131,6 +2145,10 @@ packages:
 
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
+
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -2228,6 +2246,22 @@ packages:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
 
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -2292,6 +2326,15 @@ packages:
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  stripe@18.5.0:
+    resolution: {integrity: sha512-Hp+wFiEQtCB0LlNgcFh5uVyKznpDjzyUZ+CNVEf+I3fhlYvh7rZruIg+jOwzJRCpy0ZTPMjlzm7J2/M2N6d+DA==}
+    engines: {node: '>=12.*'}
+    peerDependencies:
+      '@types/node': '>=12.x.x'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -3347,6 +3390,11 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
   caniuse-lite@1.0.30001770: {}
 
   ccount@2.0.1: {}
@@ -4293,6 +4341,8 @@ snapshots:
 
   node-releases@2.0.27: {}
 
+  object-inspect@1.13.4: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -4362,6 +4412,10 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
 
   rc@1.2.8:
     dependencies:
@@ -4512,6 +4566,34 @@ snapshots:
 
   shell-quote@1.8.3: {}
 
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
@@ -4577,6 +4659,12 @@ snapshots:
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
+
+  stripe@18.5.0(@types/node@22.19.11):
+    dependencies:
+      qs: 6.15.1
+    optionalDependencies:
+      '@types/node': 22.19.11
 
   style-to-js@1.1.21:
     dependencies:

--- a/tests/integration/billing.test.ts
+++ b/tests/integration/billing.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import Stripe from 'stripe';
+import { createTestDb } from './helpers/db.js';
+import {
+  UserTrialRepository,
+  TrialService,
+  AllowedUserRepository,
+  type DB,
+} from '@planner/core';
+import { BillingService, type BillingConfig } from '@planner/api';
+
+const TEST_WEBHOOK_SECRET = 'whsec_test_secret';
+const PRICE_MONTHLY = 'price_test_monthly';
+const PRICE_YEARLY = 'price_test_yearly';
+
+const config: BillingConfig = {
+  secretKey: 'sk_test_placeholder',
+  webhookSecret: TEST_WEBHOOK_SECRET,
+  priceMonthly: PRICE_MONTHLY,
+  priceYearly: PRICE_YEARLY,
+};
+
+let db: DB;
+let trialRepo: UserTrialRepository;
+let trialService: TrialService;
+let billing: BillingService;
+let stripeForSigning: Stripe;
+
+beforeEach(() => {
+  db = createTestDb();
+  trialRepo = new UserTrialRepository(db);
+  const allowedUserRepo = new AllowedUserRepository(db);
+  trialService = new TrialService(trialRepo, allowedUserRepo);
+  billing = new BillingService(trialRepo, config);
+  stripeForSigning = new Stripe(config.secretKey);
+
+  // Seed a trial row so we have something to mark active/cancelled.
+  trialService.ensureTrial('github:alice');
+  trialRepo.update('github:alice', {
+    stripeCustomerId: 'cus_test_123',
+    updatedAt: new Date().toISOString(),
+  });
+});
+
+function signedRequest(payload: unknown): { body: string; signature: string } {
+  const body = JSON.stringify(payload);
+  const signature = stripeForSigning.webhooks.generateTestHeaderString({
+    payload: body,
+    secret: TEST_WEBHOOK_SECRET,
+  });
+  return { body, signature };
+}
+
+function stripeSubscription(overrides: Partial<Stripe.Subscription> = {}): Stripe.Subscription {
+  const periodEnd = Math.floor(new Date('2026-05-19T00:00:00Z').getTime() / 1000);
+  return {
+    id: 'sub_test_1',
+    object: 'subscription',
+    customer: 'cus_test_123',
+    status: 'active',
+    items: {
+      object: 'list',
+      data: [
+        {
+          id: 'si_1',
+          price: { id: PRICE_MONTHLY, object: 'price' } as Stripe.Price,
+          current_period_end: periodEnd,
+          current_period_start: periodEnd - 30 * 24 * 60 * 60,
+        } as unknown as Stripe.SubscriptionItem,
+      ],
+      has_more: false,
+      url: '',
+    },
+    ...overrides,
+  } as unknown as Stripe.Subscription;
+}
+
+describe('BillingService webhook handling', () => {
+  it('rejects requests with an invalid signature', async () => {
+    const body = JSON.stringify({ type: 'checkout.session.completed', data: { object: {} } });
+    await expect(billing.handleWebhook(body, 'invalid-signature')).rejects.toThrow();
+  });
+
+  it('marks a user active on customer.subscription.updated (monthly plan)', async () => {
+    const subscription = stripeSubscription();
+    const { body, signature } = signedRequest({
+      id: 'evt_1',
+      object: 'event',
+      type: 'customer.subscription.updated',
+      data: { object: subscription },
+    });
+
+    await billing.handleWebhook(body, signature);
+
+    const trial = trialRepo.findByUserId('github:alice')!;
+    expect(trial.subscriptionStatus).toBe('active');
+    expect(trial.stripeSubscriptionId).toBe('sub_test_1');
+    expect(trial.plan).toBe('monthly');
+    expect(trial.subscriptionExpiresAt).toBe('2026-05-19T00:00:00.000Z');
+
+    // And TrialService should now grant access even past the 7-day trial window.
+    const status = trialService.getStatus('github:alice', new Date('2026-04-30T00:00:00Z'));
+    expect(status.state).toBe('active');
+    expect(status.hasAiAccess).toBe(true);
+    expect(status.plan).toBe('monthly');
+  });
+
+  it('resolves yearly plan by price ID', async () => {
+    const sub = stripeSubscription({
+      items: {
+        object: 'list',
+        data: [
+          {
+            id: 'si_2',
+            price: { id: PRICE_YEARLY, object: 'price' } as Stripe.Price,
+            current_period_end: Math.floor(new Date('2027-04-19T00:00:00Z').getTime() / 1000),
+            current_period_start: Math.floor(new Date('2026-04-19T00:00:00Z').getTime() / 1000),
+          } as unknown as Stripe.SubscriptionItem,
+        ],
+        has_more: false,
+        url: '',
+      } as Stripe.Subscription['items'],
+    });
+    const { body, signature } = signedRequest({
+      id: 'evt_2',
+      object: 'event',
+      type: 'customer.subscription.updated',
+      data: { object: sub },
+    });
+
+    await billing.handleWebhook(body, signature);
+    expect(trialRepo.findByUserId('github:alice')!.plan).toBe('yearly');
+  });
+
+  it('flips status to cancelled on customer.subscription.deleted', async () => {
+    trialRepo.update('github:alice', {
+      subscriptionStatus: 'active',
+      plan: 'monthly',
+      updatedAt: new Date().toISOString(),
+    });
+
+    const sub = stripeSubscription({ status: 'canceled' });
+    const { body, signature } = signedRequest({
+      id: 'evt_3',
+      object: 'event',
+      type: 'customer.subscription.deleted',
+      data: { object: sub },
+    });
+
+    await billing.handleWebhook(body, signature);
+    expect(trialRepo.findByUserId('github:alice')!.subscriptionStatus).toBe('cancelled');
+  });
+
+  it('marks past_due on invoice.payment_failed', async () => {
+    const { body, signature } = signedRequest({
+      id: 'evt_4',
+      object: 'event',
+      type: 'invoice.payment_failed',
+      data: { object: { id: 'in_1', object: 'invoice', customer: 'cus_test_123' } },
+    });
+
+    await billing.handleWebhook(body, signature);
+    expect(trialRepo.findByUserId('github:alice')!.subscriptionStatus).toBe('past_due');
+  });
+
+  it('looks up user via stripe_customer_id, not metadata', async () => {
+    // github:bob has no stripe_customer_id → the event targets alice's customer.
+    const sub = stripeSubscription();
+    const { body, signature } = signedRequest({
+      id: 'evt_5',
+      object: 'event',
+      type: 'customer.subscription.updated',
+      data: { object: sub },
+    });
+
+    await billing.handleWebhook(body, signature);
+
+    // Alice was updated (matched via her stripe_customer_id)
+    expect(trialRepo.findByUserId('github:alice')!.subscriptionStatus).toBe('active');
+  });
+});
+
+describe('BillingService checkout + portal', () => {
+  it('creates a stripe customer on first checkout and reuses it', async () => {
+    trialService.ensureTrial('github:new-user');
+
+    // Stripe's SDK attaches resources per-instance, so stub the actual
+    // instance our BillingService is holding.
+    const stripeInstance = (billing as unknown as { stripe: Stripe }).stripe;
+    const createCustomer = vi
+      .spyOn(stripeInstance.customers, 'create')
+      .mockResolvedValue({ id: 'cus_freshly_created' } as Stripe.Customer);
+    const createSession = vi
+      .spyOn(stripeInstance.checkout.sessions, 'create')
+      .mockResolvedValue({ url: 'https://checkout.stripe.com/test' } as Stripe.Checkout.Session);
+
+    const { url } = await billing.createCheckoutSession(
+      'github:new-user',
+      'monthly',
+      'https://example.com',
+      null
+    );
+    expect(url).toBe('https://checkout.stripe.com/test');
+    expect(createCustomer).toHaveBeenCalledTimes(1);
+    expect(createSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: 'subscription',
+        customer: 'cus_freshly_created',
+        line_items: [{ price: PRICE_MONTHLY, quantity: 1 }],
+      })
+    );
+
+    expect(trialRepo.findByUserId('github:new-user')!.stripeCustomerId).toBe(
+      'cus_freshly_created'
+    );
+
+    createCustomer.mockClear();
+    await billing.createCheckoutSession('github:new-user', 'yearly', 'https://example.com', null);
+    expect(createCustomer).not.toHaveBeenCalled();
+
+    createCustomer.mockRestore();
+    createSession.mockRestore();
+  });
+
+  it('refuses to open the portal without an existing stripe customer', async () => {
+    trialService.ensureTrial('github:no-customer');
+    await expect(
+      billing.createPortalSession('github:no-customer', 'https://example.com')
+    ).rejects.toThrow(/subscribe first/i);
+  });
+});


### PR DESCRIPTION
## Summary
- Wires **€1/month** and **€10/year** Stripe subscriptions to the trial gate shipped in #9.
- New endpoints: `POST /api/billing/checkout`, `POST /api/billing/portal`, `POST /api/billing/webhook`, `GET /api/billing/status`, `GET /api/billing/self`.
- `/subscribe` buttons now redirect to Stripe Checkout; a `/subscribe/success` page polls trial state until the webhook updates the DB.
- Webhook handler covers `checkout.session.completed`, `customer.subscription.updated`, `customer.subscription.deleted`, and `invoice.payment_failed`.
- Adds `stripe_customer_id` + `stripe_subscription_id` columns to `user_trials` (with ALTERs for existing DBs).

## How it works
- On first checkout we create a Stripe `Customer` with `metadata.userId`, store its id on `user_trials`, then open a Checkout Session for it. Subsequent checkouts reuse the customer.
- Webhooks resolve the user by `stripe_customer_id` (fast path) with a `customer.metadata.userId` fallback.
- `applySubscription()` maps the subscription's first price ID to `monthly`/`yearly` using the env var price IDs, then writes `subscription_status`, `plan`, and `subscription_expires_at` (from `items.data[0].current_period_end`).
- If any `PLANNER_STRIPE_*` env var is missing, `billingService` is null and the UI shows a "Payments not configured" banner — trial gate still works, just no exit path.

## Env vars (new)
| Variable | Purpose |
|---|---|
| `PLANNER_STRIPE_SECRET_KEY` | `sk_live_…` or `sk_test_…` |
| `PLANNER_STRIPE_WEBHOOK_SECRET` | `whsec_…` from endpoint dashboard (or `stripe listen` in dev) |
| `PLANNER_STRIPE_PRICE_MONTHLY` | Stripe Price ID for €1/mo |
| `PLANNER_STRIPE_PRICE_YEARLY` | Stripe Price ID for €10/yr |

## Test plan
Local dev:
- [ ] Create Product + two Prices in Stripe test mode; copy price IDs + secret key into env
- [ ] `stripe listen --forward-to localhost:3000/api/billing/webhook` — copy `whsec_…` into env
- [ ] `pnpm dev:full`, log in, visit `/subscribe`, click Monthly → redirected to Stripe Checkout
- [ ] Complete with `4242 4242 4242 4242` → redirected to `/subscribe/success`
- [ ] Within ~6s banner disappears, `/api/auth/trial` returns `state: 'active'`, plan: `monthly`
- [ ] AI chat works past day-7 mark (simulate by `UPDATE user_trials SET trial_expires_at = '2020-01-01'`)
- [ ] Click "Manage subscription" → Stripe Customer Portal opens; cancel → webhook flips row to `cancelled`

Production (after merge):
- [ ] Same dashboard flow with live-mode keys + price IDs
- [ ] Register webhook at `https://ye-planner.fly.dev/api/billing/webhook`, subscribe to the 4 events

## Known follow-ups
- Email receipts via Stripe dashboard settings (no code needed)
- Grace period: `past_due` still blocks AI — may want a N-day grace window
- Apple/Google Pay buttons (Checkout supports them automatically once domain is verified in Stripe)