### PR TITLE
🐛 Fix web UI bugs: broken quick-actions, auth lockout, a11y & forms

### DIFF
--- a/packages/api/src/middleware/error.middleware.ts
+++ b/packages/api/src/middleware/error.middleware.ts
@@ -14,6 +14,8 @@ export function errorHandler(err: Error, c: Context): Response {
   if (err instanceof ChatError) {
     return c.json({ error: err.message }, 502);
   }
+  // Log the real error server-side, but never leak raw internals (SQLite/Drizzle
+  // messages, stack details) to the client.
   console.error('Unhandled error:', err);
-  return c.json({ error: err.message || 'Internal server error' }, 500);
+  return c.json({ error: 'Internal server error' }, 500);
 }

--- a/packages/api/src/routes/auth.routes.ts
+++ b/packages/api/src/routes/auth.routes.ts
@@ -175,11 +175,22 @@ export function createAuthRoutes(container: ApiContainer): Hono {
   });
 
   app.get('/trial', (c) => {
+    // Degrade gracefully like /me: with no/expired session (e.g. OAuth not
+    // configured) return a 200 sentinel instead of 401. A 401 here would trip
+    // the web client's global "401 -> /login" redirect and brick the SPA, even
+    // though all data routes are open when auth is disabled.
     const sessionId = getCookie(c, 'session');
-    if (!sessionId) return c.json({ error: 'Unauthorized' }, 401);
-    const session = sessionRepo.findById(sessionId);
+    const session = sessionId ? sessionRepo.findById(sessionId) : undefined;
     if (!session || new Date(session.expiresAt) < new Date()) {
-      return c.json({ error: 'Unauthorized' }, 401);
+      return c.json({
+        state: 'none',
+        trialStartedAt: null,
+        trialExpiresAt: null,
+        subscriptionExpiresAt: null,
+        plan: null,
+        daysRemaining: 0,
+        hasAiAccess: false,
+      });
     }
     trialService.ensureTrial(session.userId);
     return c.json(trialService.getStatus(session.userId));

--- a/packages/core/src/repositories/task.repository.ts
+++ b/packages/core/src/repositories/task.repository.ts
@@ -1,4 +1,4 @@
-import { eq, and, lte, lt, type SQL } from 'drizzle-orm';
+import { eq, ne, and, lte, lt, type SQL } from 'drizzle-orm';
 import { tasks, type Task, type NewTask } from '../db/schema.js';
 import type { DB } from '../db/connection.js';
 
@@ -34,20 +34,21 @@ export class TaskRepository {
   }
 
   findDueBy(date: string): Task[] {
+    // Anything not done counts as outstanding (todo or in_progress).
     return this.db.select().from(tasks)
-      .where(and(eq(tasks.spaceId, this.spaceId), lte(tasks.dueDate, date), eq(tasks.status, 'todo')))
+      .where(and(eq(tasks.spaceId, this.spaceId), lte(tasks.dueDate, date), ne(tasks.status, 'done')))
       .all();
   }
 
   findOverdue(today: string): Task[] {
     return this.db.select().from(tasks)
-      .where(and(eq(tasks.spaceId, this.spaceId), lt(tasks.dueDate, today), eq(tasks.status, 'todo')))
+      .where(and(eq(tasks.spaceId, this.spaceId), lt(tasks.dueDate, today), ne(tasks.status, 'done')))
       .all();
   }
 
   findDueOn(date: string): Task[] {
     return this.db.select().from(tasks)
-      .where(and(eq(tasks.spaceId, this.spaceId), eq(tasks.dueDate, date), eq(tasks.status, 'todo')))
+      .where(and(eq(tasks.spaceId, this.spaceId), eq(tasks.dueDate, date), ne(tasks.status, 'done')))
       .all();
   }
 

--- a/packages/core/src/services/goal.service.ts
+++ b/packages/core/src/services/goal.service.ts
@@ -138,6 +138,9 @@ export class GoalService {
   toggleMilestone(msId: string): Milestone {
     const ms = this.milestoneRepo.findById(msId);
     if (!ms) throw new NotFoundError('Milestone', msId);
+    // milestoneRepo is not space-scoped; confirm the parent goal is in this
+    // space before mutating, so a request can't touch another space's data.
+    if (!this.goalRepo.findById(ms.goalId)) throw new NotFoundError('Milestone', msId);
     const updated = this.milestoneRepo.update(msId, { done: !ms.done })!;
     this.recalcProgress(ms.goalId);
     return updated;
@@ -146,6 +149,7 @@ export class GoalService {
   removeMilestone(msId: string): void {
     const ms = this.milestoneRepo.findById(msId);
     if (!ms) throw new NotFoundError('Milestone', msId);
+    if (!this.goalRepo.findById(ms.goalId)) throw new NotFoundError('Milestone', msId);
     const goalId = ms.goalId;
     this.milestoneRepo.delete(msId);
     this.recalcProgress(goalId);

--- a/packages/web/src/api/chat.api.ts
+++ b/packages/web/src/api/chat.api.ts
@@ -45,45 +45,60 @@ export const chatApi = {
       const decoder = new TextDecoder();
       let buffer = '';
 
+      // Dispatch one complete SSE event block. A block may carry multiple
+      // `data:` lines (server splits a payload's newlines across them); they
+      // must be rejoined with '\n' to reconstruct the original token/text.
+      const dispatch = (block: string) => {
+        let event = '';
+        const dataParts: string[] = [];
+        for (const line of block.split('\n')) {
+          if (line.startsWith('event:')) {
+            event = line.slice(line.startsWith('event: ') ? 7 : 6);
+          } else if (line.startsWith('data:')) {
+            dataParts.push(line.slice(line.startsWith('data: ') ? 6 : 5));
+          }
+        }
+        if (!event) return;
+        const data = dataParts.join('\n');
+
+        switch (event) {
+          case 'token':
+            callbacks.onToken(data);
+            break;
+          case 'tool_call': {
+            const tc = JSON.parse(data);
+            callbacks.onToolCall(tc.name, tc.args);
+            break;
+          }
+          case 'tool_result': {
+            const tr = JSON.parse(data);
+            callbacks.onToolResult(tr.name, tr.result);
+            break;
+          }
+          case 'complete':
+            callbacks.onComplete(data);
+            break;
+          case 'error':
+            callbacks.onError(data);
+            break;
+        }
+      };
+
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
 
         buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split('\n');
-        buffer = lines.pop() ?? '';
-
-        for (const line of lines) {
-          if (line.startsWith('event: ')) {
-            const event = line.slice(7);
-            const dataLine = lines[lines.indexOf(line) + 1];
-            if (!dataLine?.startsWith('data: ')) continue;
-            const data = dataLine.slice(6);
-
-            switch (event) {
-              case 'token':
-                callbacks.onToken(data);
-                break;
-              case 'tool_call': {
-                const tc = JSON.parse(data);
-                callbacks.onToolCall(tc.name, tc.args);
-                break;
-              }
-              case 'tool_result': {
-                const tr = JSON.parse(data);
-                callbacks.onToolResult(tr.name, tr.result);
-                break;
-              }
-              case 'complete':
-                callbacks.onComplete(data);
-                break;
-              case 'error':
-                callbacks.onError(data);
-                break;
-            }
-          }
+        // Events are separated by a blank line; everything up to the last
+        // '\n\n' is complete, the remainder stays buffered for the next chunk.
+        let sepIdx: number;
+        while ((sepIdx = buffer.indexOf('\n\n')) !== -1) {
+          const block = buffer.slice(0, sepIdx);
+          buffer = buffer.slice(sepIdx + 2);
+          if (block.trim()) dispatch(block);
         }
       }
+      if (buffer.trim()) dispatch(buffer);
     }).catch((err) => {
       if (err.name !== 'AbortError') {
         callbacks.onError(err.message);

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -1,4 +1,4 @@
-class ApiError extends Error {
+export class ApiError extends Error {
   constructor(public status: number, message: string) {
     super(message);
     this.name = 'ApiError';
@@ -13,7 +13,11 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
   });
 
   if (res.status === 401) {
-    window.location.href = '/login';
+    // Advisory auth-status endpoints should degrade gracefully; only a 401 on a
+    // real data request means the session is gone and we should go to /login.
+    if (!path.startsWith('/api/auth/')) {
+      window.location.href = '/login';
+    }
     throw new ApiError(401, 'Unauthorized');
   }
 

--- a/packages/web/src/api/types.ts
+++ b/packages/web/src/api/types.ts
@@ -114,7 +114,7 @@ export interface Message {
   position: number;
 }
 
-export type TrialStatusState = 'trial' | 'trial_expired' | 'active' | 'admin';
+export type TrialStatusState = 'trial' | 'trial_expired' | 'active' | 'admin' | 'none';
 
 export interface TrialStatus {
   state: TrialStatusState;

--- a/packages/web/src/components/chat/chat-panel.tsx
+++ b/packages/web/src/components/chat/chat-panel.tsx
@@ -46,8 +46,17 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages, streamTokens]);
 
+  // Abort any in-flight stream when the panel unmounts (e.g. closed via 'c' or
+  // the Close button) so its onComplete doesn't fire setState on a dead panel.
+  useEffect(() => {
+    return () => controllerRef.current?.abort();
+  }, []);
+
   async function handleSend() {
     if (!input.trim() || streaming) return;
+
+    // Cancel any prior stream before starting a new one.
+    controllerRef.current?.abort();
 
     let convId = activeConvId;
     if (!convId) {
@@ -98,7 +107,14 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
         <div className="flex gap-2">
           {activeConvId && (
             <button
-              onClick={() => { setActiveConvId(null); setMessages([]); }}
+              onClick={() => {
+                controllerRef.current?.abort();
+                setStreaming(false);
+                setStreamTokens('');
+                setStreamEvents([]);
+                setActiveConvId(null);
+                setMessages([]);
+              }}
               className="text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text-accent)]"
             >
               New
@@ -171,7 +187,7 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
             }}
             placeholder="Ask the AI..."
             rows={2}
-            className="flex-1 resize-none px-3 py-2 rounded bg-[var(--color-bg)] border border-[var(--color-border)] text-[var(--color-text-primary)] text-sm focus:outline-none focus:border-[var(--color-border-active)]"
+            className="flex-1 resize-none px-3 py-2 rounded bg-[var(--color-bg)] border border-[var(--color-border)] text-[var(--color-text-primary)] text-sm focus:outline-none focus:border-[var(--color-border-active)] focus-visible:ring-2 focus-visible:ring-[var(--color-border-active)]"
           />
           <button
             onClick={handleSend}

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useThemeStore } from '../../stores/theme.store';
 import { useCurrentSpace } from '../../contexts/space-context';
 import { useSpaces } from '../../hooks/use-api';
@@ -25,9 +25,20 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
   const { themeName, cycleTheme } = useThemeStore();
   const { spaceId } = useCurrentSpace();
   const { data: spaces } = useSpaces();
+  const queryClient = useQueryClient();
   const [spaceSwitcherOpen, setSpaceSwitcherOpen] = useState(false);
 
-  const { data: authMe } = useQuery({ queryKey: ['auth', 'me'], queryFn: () => api.get<{ isAdmin?: boolean }>('/api/auth/me') });
+  const { data: authMe } = useQuery({ queryKey: ['auth', 'me'], queryFn: () => api.get<{ authenticated?: boolean; isAdmin?: boolean }>('/api/auth/me') });
+
+  const handleLogout = async () => {
+    try {
+      await api.post('/api/auth/logout');
+    } finally {
+      queryClient.clear();
+      // Full navigation so the cleared cookie/cache state fully resets.
+      window.location.href = '/login';
+    }
+  };
   const currentSpace = spaces?.find(s => s.id === spaceId);
   const basePath = `/spaces/${spaceId}`;
 
@@ -122,6 +133,15 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
           <span className="font-mono mr-2">t</span>
           Theme: {themeName}
         </button>
+        {authMe?.authenticated && (
+          <button
+            onClick={handleLogout}
+            className="w-full text-left text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-error)] transition-colors"
+          >
+            <span className="font-mono mr-2">{'⏻'}</span>
+            Sign out
+          </button>
+        )}
       </div>
     </aside>
   );

--- a/packages/web/src/components/layout/trial-banner.tsx
+++ b/packages/web/src/components/layout/trial-banner.tsx
@@ -4,7 +4,8 @@ import { useTrial } from '../../hooks/use-api';
 export function TrialBanner() {
   const { data } = useTrial();
   if (!data) return null;
-  if (data.state === 'admin' || data.state === 'active') return null;
+  // 'none' = no/expired session (e.g. auth disabled); show no banner.
+  if (data.state === 'admin' || data.state === 'active' || data.state === 'none') return null;
 
   if (data.state === 'trial_expired') {
     return (

--- a/packages/web/src/components/shared/inline-form.tsx
+++ b/packages/web/src/components/shared/inline-form.tsx
@@ -1,29 +1,48 @@
 import { useState, useRef, useEffect } from 'react';
 import { useKeyboardStore } from '../../stores/keyboard.store';
 
+interface FieldOption {
+  value: string;
+  label: string;
+}
+
+interface Field {
+  name: string;
+  label: string;
+  type?: 'text' | 'date' | 'select' | 'textarea';
+  required?: boolean;
+  options?: FieldOption[];
+  placeholder?: string;
+}
+
 interface InlineFormProps {
   open: boolean;
   initialValues?: Record<string, string>;
-  fields: Array<{ name: string; label: string; type?: string; required?: boolean }>;
+  fields: Field[];
   onSubmit: (values: Record<string, string>) => void;
   onCancel: () => void;
   submitLabel?: string;
 }
 
+type FirstFieldEl = HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
+
 export function InlineForm({ open, initialValues = {}, fields, onSubmit, onCancel, submitLabel = 'Save' }: InlineFormProps) {
   const [values, setValues] = useState<Record<string, string>>(initialValues);
-  const firstInputRef = useRef<HTMLInputElement>(null);
+  const firstFieldRef = useRef<FirstFieldEl>(null);
   const setInputFocused = useKeyboardStore((s) => s.setInputFocused);
 
   useEffect(() => {
     if (open) {
       setValues(initialValues);
-      setTimeout(() => firstInputRef.current?.focus(), 50);
+      setTimeout(() => firstFieldRef.current?.focus(), 50);
     }
     return () => setInputFocused(false);
   }, [open, setInputFocused]);
 
   if (!open) return null;
+
+  const fieldClass =
+    'w-full px-3 py-2.5 rounded-lg bg-[var(--color-bg)] border border-[var(--color-border)] text-[var(--color-text-primary)] text-sm focus:outline-none focus:border-[var(--color-border-active)] focus-visible:ring-2 focus-visible:ring-[var(--color-border-active)] transition-colors';
 
   return (
     <div className="rounded-lg border border-[var(--color-border-active)] bg-[var(--color-bg-panel)] p-4">
@@ -37,21 +56,56 @@ export function InlineForm({ open, initialValues = {}, fields, onSubmit, onCance
         }}
         className="space-y-3"
       >
-        {fields.map((field, i) => (
-          <div key={field.name}>
-            <label className="block text-xs text-[var(--color-text-secondary)] mb-1.5">{field.label}</label>
-            <input
-              ref={i === 0 ? firstInputRef : undefined}
-              type={field.type ?? 'text'}
-              value={values[field.name] ?? ''}
-              onChange={(e) => setValues((prev) => ({ ...prev, [field.name]: e.target.value }))}
-              required={field.required}
-              onFocus={() => setInputFocused(true)}
-              onBlur={() => setInputFocused(false)}
-              className="w-full px-3 py-2.5 rounded-lg bg-[var(--color-bg)] border border-[var(--color-border)] text-[var(--color-text-primary)] text-sm focus:outline-none focus:border-[var(--color-border-active)] transition-colors"
-            />
-          </div>
-        ))}
+        {fields.map((field, i) => {
+          const value = values[field.name] ?? '';
+          const onChange = (v: string) => setValues((prev) => ({ ...prev, [field.name]: v }));
+          return (
+            <div key={field.name}>
+              <label className="block text-xs text-[var(--color-text-secondary)] mb-1.5">{field.label}</label>
+              {field.type === 'select' ? (
+                <select
+                  ref={i === 0 ? (firstFieldRef as React.RefObject<HTMLSelectElement>) : undefined}
+                  value={value}
+                  onChange={(e) => onChange(e.target.value)}
+                  required={field.required}
+                  onFocus={() => setInputFocused(true)}
+                  onBlur={() => setInputFocused(false)}
+                  className={fieldClass}
+                >
+                  {field.options?.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              ) : field.type === 'textarea' ? (
+                <textarea
+                  ref={i === 0 ? (firstFieldRef as React.RefObject<HTMLTextAreaElement>) : undefined}
+                  value={value}
+                  onChange={(e) => onChange(e.target.value)}
+                  required={field.required}
+                  rows={3}
+                  placeholder={field.placeholder}
+                  onFocus={() => setInputFocused(true)}
+                  onBlur={() => setInputFocused(false)}
+                  className={`${fieldClass} resize-none`}
+                />
+              ) : (
+                <input
+                  ref={i === 0 ? (firstFieldRef as React.RefObject<HTMLInputElement>) : undefined}
+                  type={field.type ?? 'text'}
+                  value={value}
+                  onChange={(e) => onChange(e.target.value)}
+                  required={field.required}
+                  placeholder={field.placeholder}
+                  onFocus={() => setInputFocused(true)}
+                  onBlur={() => setInputFocused(false)}
+                  className={fieldClass}
+                />
+              )}
+            </div>
+          );
+        })}
         <div className="flex justify-end gap-2 pt-2">
           <button
             type="button"

--- a/packages/web/src/hooks/use-keyboard.ts
+++ b/packages/web/src/hooks/use-keyboard.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useNavigate, useLocation, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useKeyboardStore } from '../stores/keyboard.store';
 import { useThemeStore } from '../stores/theme.store';
 
@@ -7,7 +7,6 @@ const SCREEN_SUFFIXES = ['', '/areas', '/goals', '/tasks', '/habits'];
 
 export function useKeyboard() {
   const navigate = useNavigate();
-  const location = useLocation();
   const { spaceId } = useParams<{ spaceId: string }>();
   const { inputFocused, overlayOpen } = useKeyboardStore();
   const cycleTheme = useThemeStore((s) => s.cycleTheme);
@@ -40,16 +39,9 @@ export function useKeyboard() {
         return;
       }
 
-      // Tab / Shift+Tab for prev/next screen
-      if (e.key === 'Tab') {
-        e.preventDefault();
-        const currentIdx = screenRoutes.indexOf(location.pathname);
-        if (currentIdx === -1) return;
-        const delta = e.shiftKey ? -1 : 1;
-        const nextIdx = (currentIdx + delta + screenRoutes.length) % screenRoutes.length;
-        navigate(screenRoutes[nextIdx]);
-        return;
-      }
+      // Note: bare Tab is intentionally NOT captured for screen switching —
+      // doing so would suppress native focus traversal (WCAG 2.1.1). Use the
+      // 1-5 shortcuts (or the sidebar) to switch screens.
 
       // Theme toggle
       if (e.key === 't' && !e.metaKey && !e.ctrlKey) {
@@ -66,5 +58,5 @@ export function useKeyboard() {
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [inputFocused, overlayOpen, navigate, location.pathname, cycleTheme, spaceId]);
+  }, [inputFocused, overlayOpen, navigate, cycleTheme, spaceId]);
 }

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -1,28 +1,31 @@
 @import "tailwindcss";
 
+/* Static defaults (neon theme) so the app renders correctly before — or if —
+   the runtime applyTheme() in main.tsx sets the :root vars. applyTheme still
+   overrides these on documentElement for live theme switching. */
 @theme {
-  --color-bg: var(--color-bg);
-  --color-bg-panel: var(--color-bg-panel);
-  --color-bg-highlight: var(--color-bg-highlight);
-  --color-text-primary: var(--color-text-primary);
-  --color-text-secondary: var(--color-text-secondary);
-  --color-text-accent: var(--color-text-accent);
-  --color-success: var(--color-success);
-  --color-warning: var(--color-warning);
-  --color-error: var(--color-error);
-  --color-priority-low: var(--color-priority-low);
-  --color-priority-med: var(--color-priority-med);
-  --color-priority-high: var(--color-priority-high);
-  --color-priority-urgent: var(--color-priority-urgent);
-  --color-accent-1: var(--color-accent-1);
-  --color-accent-2: var(--color-accent-2);
-  --color-streak-fire: var(--color-streak-fire);
-  --color-progress-fill: var(--color-progress-fill);
-  --color-progress-track: var(--color-progress-track);
-  --color-border: var(--color-border);
-  --color-border-active: var(--color-border-active);
-  --color-tab-active: var(--color-tab-active);
-  --color-tab-inactive: var(--color-tab-inactive);
+  --color-bg: #0a0a1a;
+  --color-bg-panel: #111128;
+  --color-bg-highlight: #1a1a3e;
+  --color-text-primary: #e0e0ff;
+  --color-text-secondary: #7777aa;
+  --color-text-accent: #00d4ff;
+  --color-success: #00ff88;
+  --color-warning: #ffaa00;
+  --color-error: #ff3366;
+  --color-priority-low: #4488cc;
+  --color-priority-med: #00d4ff;
+  --color-priority-high: #ff6600;
+  --color-priority-urgent: #ff3366;
+  --color-accent-1: #00d4ff;
+  --color-accent-2: #ff44aa;
+  --color-streak-fire: #ff6600;
+  --color-progress-fill: #00d4ff;
+  --color-progress-track: #222244;
+  --color-border: #333366;
+  --color-border-active: #00d4ff;
+  --color-tab-active: #00d4ff;
+  --color-tab-inactive: #9a9ad0;
 }
 
 body {
@@ -32,8 +35,23 @@ body {
   -webkit-tap-highlight-color: transparent;
 }
 
+html,
+body {
+  min-height: 100%;
+  /* Fill overscroll / rubber-band areas with the theme background instead of
+     the user-agent default white, which flashes on these very dark themes. */
+  background: var(--color-bg);
+}
+
 html {
   scroll-behavior: smooth;
+}
+
+/* Visible keyboard-focus indicator (WCAG 2.4.7). The UI is heavily keyboard
+   driven, so every focusable element needs a consistent ring. */
+*:focus-visible {
+  outline: 2px solid var(--color-border-active);
+  outline-offset: 2px;
 }
 
 * {

--- a/packages/web/src/pages/admin.tsx
+++ b/packages/web/src/pages/admin.tsx
@@ -1,12 +1,29 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { fetchAllowedUsers, addAllowedUser, removeAllowedUser, type AllowedUser } from '../api/admin.api';
+import { useAuthMe } from '../hooks/use-api';
+import { ApiError } from '../api/client';
 
 export function AdminPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { data: users, isLoading } = useQuery({ queryKey: ['admin', 'allowed-users'], queryFn: fetchAllowedUsers });
+
+  // Gate the route: redirect anyone who isn't a confirmed admin (the sidebar
+  // only hides the link; the route itself was previously reachable directly).
+  const { data: authMe, isLoading: authLoading } = useAuthMe();
+  useEffect(() => {
+    if (!authLoading && authMe && !authMe.isAdmin) {
+      navigate('/', { replace: true });
+    }
+  }, [authLoading, authMe, navigate]);
+
+  const { data: users, isLoading, isError: usersError, error: usersErrorObj } = useQuery({
+    queryKey: ['admin', 'allowed-users'],
+    queryFn: fetchAllowedUsers,
+    enabled: authMe?.isAdmin === true,
+    retry: false,
+  });
 
   const addMutation = useMutation({
     mutationFn: (data: { provider: string; username: string }) => addAllowedUser(data.provider, data.username),
@@ -87,7 +104,13 @@ export function AdminPage() {
           )}
 
           {/* User list */}
-          {isLoading ? (
+          {usersError ? (
+            <p className="text-sm text-red-400">
+              {usersErrorObj instanceof ApiError && usersErrorObj.status === 403
+                ? 'You do not have admin access.'
+                : 'Failed to load allowed users.'}
+            </p>
+          ) : isLoading ? (
             <p className="text-sm text-[var(--color-text-secondary)]">Loading...</p>
           ) : (
             <div className="space-y-1">

--- a/packages/web/src/pages/areas.tsx
+++ b/packages/web/src/pages/areas.tsx
@@ -149,11 +149,11 @@ export function AreasPage() {
 
       <div className="space-y-2">
         {areas?.map((area, i) => (
-          <button
+          <div
             key={area.id}
             onClick={() => setDetailId(area.id)}
             data-selected={i === selectedIdx ? '' : undefined}
-            className={`w-full text-left px-4 py-3 rounded-lg flex flex-col md:flex-row md:items-center justify-between gap-1.5 transition-colors ${
+            className={`w-full text-left px-4 py-3 rounded-lg flex flex-col md:flex-row md:items-center justify-between gap-1.5 transition-colors cursor-pointer ${
               i === selectedIdx
                 ? 'bg-[var(--color-bg-highlight)] border border-[var(--color-border-active)]'
                 : 'hover:bg-[var(--color-bg-highlight)] border border-transparent'
@@ -165,12 +165,28 @@ export function AreasPage() {
                 <p className="text-xs text-[var(--color-text-secondary)] mt-0.5 truncate">{area.description}</p>
               )}
             </div>
-            <div className="flex gap-3 md:gap-4 text-xs text-[var(--color-text-secondary)] shrink-0">
-              <span>{area.goalCount} goals</span>
-              <span>{area.taskCount} tasks</span>
-              <span>{area.habitCount} habits</span>
+            <div className="flex items-center gap-3 md:gap-4 shrink-0">
+              <div className="flex gap-3 md:gap-4 text-xs text-[var(--color-text-secondary)]">
+                <span>{area.goalCount} goal{area.goalCount === 1 ? '' : 's'}</span>
+                <span>{area.taskCount} task{area.taskCount === 1 ? '' : 's'}</span>
+                <span>{area.habitCount} habit{area.habitCount === 1 ? '' : 's'}</span>
+              </div>
+              <div className="flex items-center gap-1">
+                <button
+                  onClick={(e) => { e.stopPropagation(); setEditId(area.id); }}
+                  className="px-2.5 py-1.5 text-xs rounded border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-accent)] hover:border-[var(--color-border-active)] transition-colors"
+                >
+                  Edit
+                </button>
+                <button
+                  onClick={(e) => { e.stopPropagation(); setDeleteId(area.id); }}
+                  className="px-2.5 py-1.5 text-xs rounded border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:text-[var(--color-error)] hover:border-[var(--color-error)] transition-colors"
+                >
+                  Delete
+                </button>
+              </div>
             </div>
-          </button>
+          </div>
         ))}
         {areas?.length === 0 && (
           <div className="text-center py-12">

--- a/packages/web/src/pages/dashboard.tsx
+++ b/packages/web/src/pages/dashboard.tsx
@@ -95,9 +95,14 @@ export function DashboardPage() {
           <p className="text-2xl font-bold text-[var(--color-success)]">{summary.habitsDone}/{summary.habitsDue}</p>
         </Panel>
         <Panel>
-          <div className="flex items-center justify-between mb-1">
-            <p className="text-xs text-[var(--color-text-secondary)]">{summary.bestActiveStreak ? summary.bestActiveStreak.habit : 'Streaks'}</p>
-            <span className="text-base opacity-60">~</span>
+          <div className="flex items-center justify-between gap-1 mb-1">
+            <p
+              className="text-xs text-[var(--color-text-secondary)] truncate min-w-0"
+              title={summary.bestActiveStreak ? summary.bestActiveStreak.habit : undefined}
+            >
+              {summary.bestActiveStreak ? summary.bestActiveStreak.habit : 'Streaks'}
+            </p>
+            <span className="text-base opacity-60 shrink-0">~</span>
           </div>
           {summary.bestActiveStreak ? (
             <p className="text-2xl font-bold text-[var(--color-streak-fire)]">{summary.bestActiveStreak.streak}</p>

--- a/packages/web/src/pages/goals.tsx
+++ b/packages/web/src/pages/goals.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useGoals, useGoal, useCreateGoal, useUpdateGoal, useDeleteGoal } from '../hooks/use-api';
 import { goalsApi } from '../api/goals.api';
 import { useQueryClient } from '@tanstack/react-query';
+import { useCurrentSpace } from '../contexts/space-context';
 import { useKeyboardStore } from '../stores/keyboard.store';
 import { Panel } from '../components/shared/panel';
 import { PriorityBadge } from '../components/shared/priority-badge';
@@ -12,7 +13,15 @@ import { ConfirmDialog } from '../components/shared/confirm-dialog';
 
 const FILTERS = ['active', 'done', 'archived', 'all'] as const;
 
+const PRIORITY_OPTIONS = [
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+  { value: 'urgent', label: 'Urgent' },
+];
+
 export function GoalsPage() {
+  const { spaceId } = useCurrentSpace();
   const [filter, setFilter] = useState<string>('active');
   const filterParam = filter === 'all' ? undefined : filter;
   const { data: goals, isLoading } = useGoals({ status: filterParam });
@@ -30,6 +39,8 @@ export function GoalsPage() {
   const { data: detail } = useGoal(detailId ?? '');
   const { inputFocused, overlayOpen } = useKeyboardStore();
 
+  const refreshGoals = () => qc.invalidateQueries({ queryKey: ['spaces', spaceId, 'goals'] });
+
   useEffect(() => {
     document.querySelector('[data-selected]')?.scrollIntoView({ block: 'nearest' });
   }, [selectedIdx]);
@@ -38,6 +49,23 @@ export function GoalsPage() {
     function handleKey(e: KeyboardEvent) {
       if (inputFocused || overlayOpen) return;
       if (!goals) return;
+
+      // In the detail view, route mutating shortcuts at the open goal, not the
+      // (possibly different) list selection.
+      if (detailId) {
+        switch (e.key) {
+          case 'Backspace':
+            setDetailId(null);
+            break;
+          case 'd':
+            goalsApi.markDone(spaceId, detailId).then(refreshGoals);
+            break;
+          case 'x':
+            setDeleteId(detailId);
+            break;
+        }
+        return;
+      }
 
       switch (e.key) {
         case 'j': case 'ArrowDown':
@@ -55,9 +83,6 @@ export function GoalsPage() {
         case 'Enter':
           if (goals[selectedIdx]) setDetailId(goals[selectedIdx].id);
           break;
-        case 'Backspace':
-          setDetailId(null);
-          break;
         case 'n':
           setShowAdd(true);
           break;
@@ -69,7 +94,7 @@ export function GoalsPage() {
           break;
         case 'd':
           if (goals[selectedIdx]) {
-            goalsApi.markDone(goals[selectedIdx].id).then(() => qc.invalidateQueries({ queryKey: ['goals'] }));
+            goalsApi.markDone(spaceId, goals[selectedIdx].id).then(refreshGoals);
           }
           break;
         case 'f': case 'F': {
@@ -81,7 +106,8 @@ export function GoalsPage() {
     }
     document.addEventListener('keydown', handleKey);
     return () => document.removeEventListener('keydown', handleKey);
-  }, [inputFocused, overlayOpen, goals, selectedIdx, filter, qc]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inputFocused, overlayOpen, goals, selectedIdx, filter, qc, spaceId, detailId]);
 
   if (isLoading) return <div className="text-[var(--color-text-secondary)]">Loading...</div>;
 
@@ -95,6 +121,28 @@ export function GoalsPage() {
           <h1 className="text-xl md:text-2xl font-bold text-[var(--color-text-accent)]">{detail.title}</h1>
           <StatusBadge status={detail.status} />
           <PriorityBadge priority={detail.priority} />
+          <div className="flex items-center gap-1 ml-auto">
+            {detail.status !== 'done' && (
+              <button
+                onClick={() => goalsApi.markDone(spaceId, detail.id).then(refreshGoals)}
+                className="px-2.5 py-1.5 text-xs rounded border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:text-[var(--color-success)] hover:border-[var(--color-success)] transition-colors"
+              >
+                Mark done
+              </button>
+            )}
+            <button
+              onClick={() => setEditId(detail.id)}
+              className="px-2.5 py-1.5 text-xs rounded border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-accent)] hover:border-[var(--color-border-active)] transition-colors"
+            >
+              Edit
+            </button>
+            <button
+              onClick={() => setDeleteId(detail.id)}
+              className="px-2.5 py-1.5 text-xs rounded border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:text-[var(--color-error)] hover:border-[var(--color-error)] transition-colors"
+            >
+              Delete
+            </button>
+          </div>
         </div>
 
         <div className="flex items-center gap-3">
@@ -106,12 +154,12 @@ export function GoalsPage() {
           {detail.milestones.map((ms) => (
             <div key={ms.id} className="flex items-center gap-2 py-1">
               <button
-                onClick={() => goalsApi.toggleMilestone(ms.id).then(() => qc.invalidateQueries({ queryKey: ['goals'] }))}
+                onClick={() => goalsApi.toggleMilestone(spaceId, ms.id).then(refreshGoals)}
                 className={`w-4 h-4 rounded border text-xs flex items-center justify-center ${
                   ms.done ? 'bg-[var(--color-success)] border-[var(--color-success)] text-[var(--color-bg)]' : 'border-[var(--color-border)]'
                 }`}
               >
-                {ms.done ? '\u2713' : null}
+                {ms.done ? '✓' : null}
               </button>
               <span className={`text-sm ${ms.done ? 'line-through text-[var(--color-text-secondary)]' : 'text-[var(--color-text-primary)]'}`}>
                 {ms.title}
@@ -120,6 +168,37 @@ export function GoalsPage() {
           ))}
           {detail.milestones.length === 0 && <p className="text-xs text-[var(--color-text-secondary)]">No milestones</p>}
         </Panel>
+
+        {editId && (
+          <InlineForm
+            open
+            initialValues={{
+              title: detail.title,
+              description: detail.description ?? '',
+              priority: detail.priority,
+              targetDate: detail.targetDate ?? '',
+            }}
+            fields={[
+              { name: 'title', label: 'Title', required: true },
+              { name: 'description', label: 'Description', type: 'textarea' },
+              { name: 'priority', label: 'Priority', type: 'select', options: PRIORITY_OPTIONS },
+              { name: 'targetDate', label: 'Target Date', type: 'date' },
+            ]}
+            onSubmit={(vals) => {
+              updateGoal.mutate({ id: detail.id, title: vals.title, description: vals.description || undefined, priority: vals.priority || undefined, targetDate: vals.targetDate || undefined });
+              setEditId(null);
+            }}
+            onCancel={() => setEditId(null)}
+          />
+        )}
+
+        <ConfirmDialog
+          open={!!deleteId}
+          title="Delete Goal"
+          message="Milestones will be deleted. Tasks and habits will be unlinked."
+          onConfirm={() => { if (deleteId) { deleteGoal.mutate(deleteId); setDetailId(null); } setDeleteId(null); }}
+          onCancel={() => setDeleteId(null)}
+        />
       </div>
     );
   }
@@ -147,13 +226,15 @@ export function GoalsPage() {
 
       <InlineForm
         open={showAdd}
+        initialValues={{ priority: 'medium' }}
         fields={[
           { name: 'title', label: 'Title', required: true },
-          { name: 'description', label: 'Description' },
+          { name: 'description', label: 'Description', type: 'textarea' },
+          { name: 'priority', label: 'Priority', type: 'select', options: PRIORITY_OPTIONS },
           { name: 'targetDate', label: 'Target Date', type: 'date' },
         ]}
         onSubmit={(vals) => {
-          createGoal.mutate({ title: vals.title, description: vals.description || undefined, targetDate: vals.targetDate || undefined });
+          createGoal.mutate({ title: vals.title, description: vals.description || undefined, priority: vals.priority || undefined, targetDate: vals.targetDate || undefined });
           setShowAdd(false);
         }}
         onCancel={() => setShowAdd(false)}
@@ -166,15 +247,17 @@ export function GoalsPage() {
           initialValues={{
             title: goals?.find((g) => g.id === editId)?.title ?? '',
             description: goals?.find((g) => g.id === editId)?.description ?? '',
+            priority: goals?.find((g) => g.id === editId)?.priority ?? 'medium',
             targetDate: goals?.find((g) => g.id === editId)?.targetDate ?? '',
           }}
           fields={[
             { name: 'title', label: 'Title', required: true },
-            { name: 'description', label: 'Description' },
+            { name: 'description', label: 'Description', type: 'textarea' },
+            { name: 'priority', label: 'Priority', type: 'select', options: PRIORITY_OPTIONS },
             { name: 'targetDate', label: 'Target Date', type: 'date' },
           ]}
           onSubmit={(vals) => {
-            updateGoal.mutate({ id: editId, title: vals.title, description: vals.description || undefined, targetDate: vals.targetDate || undefined });
+            updateGoal.mutate({ id: editId, title: vals.title, description: vals.description || undefined, priority: vals.priority || undefined, targetDate: vals.targetDate || undefined });
             setEditId(null);
           }}
           onCancel={() => setEditId(null)}
@@ -183,21 +266,45 @@ export function GoalsPage() {
 
       <div className="space-y-2">
         {goals?.map((goal, i) => (
-          <button
+          <div
             key={goal.id}
             onClick={() => setDetailId(goal.id)}
             data-selected={i === selectedIdx ? '' : undefined}
-            className={`w-full text-left px-4 py-3 rounded-lg transition-colors ${
+            className={`w-full text-left px-4 py-3 rounded-lg transition-colors cursor-pointer ${
               i === selectedIdx ? 'bg-[var(--color-bg-highlight)] border border-[var(--color-border-active)]' : 'hover:bg-[var(--color-bg-highlight)] border border-transparent'
             }`}
           >
-            <span className="text-sm font-medium text-[var(--color-text-primary)]">{goal.title}</span>
+            <div className="flex items-start justify-between gap-2">
+              <span className="text-sm font-medium text-[var(--color-text-primary)]">{goal.title}</span>
+              <div className="flex items-center gap-1 shrink-0">
+                {goal.status !== 'done' && (
+                  <button
+                    onClick={(e) => { e.stopPropagation(); goalsApi.markDone(spaceId, goal.id).then(refreshGoals); }}
+                    className="px-2.5 py-1.5 text-xs rounded border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:text-[var(--color-success)] hover:border-[var(--color-success)] transition-colors"
+                  >
+                    Done
+                  </button>
+                )}
+                <button
+                  onClick={(e) => { e.stopPropagation(); setEditId(goal.id); }}
+                  className="px-2.5 py-1.5 text-xs rounded border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-accent)] hover:border-[var(--color-border-active)] transition-colors"
+                >
+                  Edit
+                </button>
+                <button
+                  onClick={(e) => { e.stopPropagation(); setDeleteId(goal.id); }}
+                  className="px-2.5 py-1.5 text-xs rounded border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:text-[var(--color-error)] hover:border-[var(--color-error)] transition-colors"
+                >
+                  Delete
+                </button>
+              </div>
+            </div>
             <div className="flex items-center gap-2 mt-1.5">
               <StatusBadge status={goal.status} />
               <PriorityBadge priority={goal.priority} />
             </div>
             <ProgressBar value={goal.progress} className="w-full mt-2" />
-          </button>
+          </div>
         ))}
         {goals?.length === 0 && (
           <div className="text-center py-12">

--- a/packages/web/src/pages/habits.tsx
+++ b/packages/web/src/pages/habits.tsx
@@ -4,6 +4,30 @@ import { useKeyboardStore } from '../stores/keyboard.store';
 import { StreakDisplay } from '../components/shared/streak-display';
 import { InlineForm } from '../components/shared/inline-form';
 import { ConfirmDialog } from '../components/shared/confirm-dialog';
+import type { Habit } from '../api/types';
+
+const FREQUENCY_OPTIONS = [
+  { value: 'daily', label: 'Daily' },
+  { value: 'weekly', label: 'Weekly' },
+  { value: 'specific_days', label: 'Specific days' },
+];
+
+/** Stored as a JSON array string e.g. "[1,3,5]" → "1,3,5" for the form. */
+function daysToInput(days: string | null | undefined): string {
+  if (!days) return '';
+  try {
+    return (JSON.parse(days) as number[]).join(',');
+  } catch {
+    return '';
+  }
+}
+
+function inputToDays(s: string): number[] {
+  return s
+    .split(',')
+    .map((x) => parseInt(x.trim(), 10))
+    .filter((n) => !isNaN(n) && n >= 0 && n <= 6);
+}
 
 export function HabitsPage() {
   const [viewMode, setViewMode] = useState<'today' | 'all'>('today');
@@ -23,6 +47,18 @@ export function HabitsPage() {
 
   const displayItems = viewMode === 'today' ? todayHabits : allHabits;
   const isToday = viewMode === 'today';
+
+  const editHabit: Habit | undefined = (allHabits ?? todayHabits)?.find((h) => h.id === editId);
+
+  function submitHabit(vals: Record<string, string>, id?: string) {
+    const frequency = vals.frequency || 'daily';
+    const days = frequency === 'specific_days' ? inputToDays(vals.days || '') : undefined;
+    if (id) {
+      updateHabit.mutate({ id, title: vals.title, frequency, days });
+    } else {
+      createHabit.mutate({ title: vals.title, frequency, days });
+    }
+  }
 
   useEffect(() => {
     document.querySelector('[data-selected]')?.scrollIntoView({ block: 'nearest' });
@@ -78,12 +114,18 @@ export function HabitsPage() {
 
   const allDone = isToday && todayHabits && todayHabits.length > 0 && todayHabits.every((h) => h.done);
 
+  const habitFields = [
+    { name: 'title', label: 'Title', required: true },
+    { name: 'frequency', label: 'Frequency', type: 'select' as const, options: FREQUENCY_OPTIONS },
+    { name: 'days', label: 'Days (specific days only — e.g. 1,3,5; 0=Sun)', placeholder: '1,3,5' },
+  ];
+
   return (
     <div className="space-y-4 max-w-2xl">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold text-[var(--color-text-accent)]">
           Habits
-          {allDone && <span className="ml-2 text-[var(--color-success)]">{'\u2728'} All done!</span>}
+          {allDone && <span className="ml-2 text-[var(--color-success)]">{'✨'} All done!</span>}
         </h1>
         <button onClick={() => setShowAdd(true)} className="px-4 py-2 text-sm rounded-lg bg-[var(--color-accent-1)] text-[var(--color-bg)] font-medium hover:opacity-90 active:opacity-80 transition-opacity">
           + New Habit
@@ -107,11 +149,10 @@ export function HabitsPage() {
 
       <InlineForm
         open={showAdd}
-        fields={[
-          { name: 'title', label: 'Title', required: true },
-        ]}
+        initialValues={{ frequency: 'daily' }}
+        fields={habitFields}
         onSubmit={(vals) => {
-          createHabit.mutate({ title: vals.title });
+          submitHabit(vals);
           setShowAdd(false);
         }}
         onCancel={() => setShowAdd(false)}
@@ -122,13 +163,13 @@ export function HabitsPage() {
         <InlineForm
           open
           initialValues={{
-            title: displayItems?.find((h) => h.id === editId)?.title ?? '',
+            title: editHabit?.title ?? '',
+            frequency: editHabit?.frequency ?? 'daily',
+            days: daysToInput(editHabit?.days),
           }}
-          fields={[
-            { name: 'title', label: 'Title', required: true },
-          ]}
+          fields={habitFields}
           onSubmit={(vals) => {
-            updateHabit.mutate({ id: editId, title: vals.title });
+            submitHabit(vals, editId);
             setEditId(null);
           }}
           onCancel={() => setEditId(null)}
@@ -163,7 +204,7 @@ export function HabitsPage() {
                       ? 'bg-[var(--color-success)] border-[var(--color-success)] text-[var(--color-bg)]'
                       : 'border-[var(--color-border)]'
                   }`}>
-                    {isDone ? '\u2713' : null}
+                    {isDone ? '✓' : null}
                   </div>
                 )}
                 <span className={`text-sm truncate ${isDone ? 'line-through text-[var(--color-text-secondary)]' : 'text-[var(--color-text-primary)]'}`}>
@@ -171,7 +212,21 @@ export function HabitsPage() {
                 </span>
                 <span className="text-xs text-[var(--color-text-secondary)] font-mono shrink-0">{habit.frequency}</span>
               </div>
-              <StreakDisplay current={habit.currentStreak} best={habit.bestStreak} />
+              <div className="flex items-center gap-2 shrink-0">
+                <StreakDisplay current={habit.currentStreak} best={habit.bestStreak} />
+                <button
+                  onClick={(e) => { e.stopPropagation(); setEditId(habit.id); }}
+                  className="px-2.5 py-1.5 text-xs rounded border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-accent)] hover:border-[var(--color-border-active)] transition-colors"
+                >
+                  Edit
+                </button>
+                <button
+                  onClick={(e) => { e.stopPropagation(); setDeleteId(habit.id); }}
+                  className="px-2.5 py-1.5 text-xs rounded border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:text-[var(--color-error)] hover:border-[var(--color-error)] transition-colors"
+                >
+                  Delete
+                </button>
+              </div>
             </div>
           );
         })}

--- a/packages/web/src/pages/tasks.tsx
+++ b/packages/web/src/pages/tasks.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useTasks, useCreateTask, useUpdateTask, useDeleteTask } from '../hooks/use-api';
 import { tasksApi } from '../api/tasks.api';
 import { useQueryClient } from '@tanstack/react-query';
+import { useCurrentSpace } from '../contexts/space-context';
 import { useKeyboardStore } from '../stores/keyboard.store';
 import { PriorityBadge } from '../components/shared/priority-badge';
 import { StatusBadge } from '../components/shared/status-badge';
@@ -10,7 +11,21 @@ import { ConfirmDialog } from '../components/shared/confirm-dialog';
 
 const FILTERS = ['all', 'todo', 'in_progress', 'done'] as const;
 
+const PRIORITY_OPTIONS = [
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+  { value: 'urgent', label: 'Urgent' },
+];
+
+/** Local calendar date as YYYY-MM-DD (matches how due dates are entered). */
+function localToday(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
 export function TasksPage() {
+  const { spaceId } = useCurrentSpace();
   const [filter, setFilter] = useState<string>('all');
   const filterParam = filter === 'all' ? undefined : filter;
   const { data: tasks, isLoading } = useTasks({ status: filterParam });
@@ -24,6 +39,11 @@ export function TasksPage() {
   const [editId, setEditId] = useState<string | null>(null);
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const { inputFocused, overlayOpen } = useKeyboardStore();
+
+  const refreshTasks = () => {
+    qc.invalidateQueries({ queryKey: ['spaces', spaceId, 'tasks'] });
+    qc.invalidateQueries({ queryKey: ['spaces', spaceId, 'status'] });
+  };
 
   useEffect(() => {
     document.querySelector('[data-selected]')?.scrollIntoView({ block: 'nearest' });
@@ -58,15 +78,12 @@ export function TasksPage() {
           break;
         case 'd':
           if (tasks[selectedIdx]) {
-            tasksApi.markDone(tasks[selectedIdx].id).then(() => {
-              qc.invalidateQueries({ queryKey: ['tasks'] });
-              qc.invalidateQueries({ queryKey: ['status'] });
-            });
+            tasksApi.markDone(spaceId, tasks[selectedIdx].id).then(refreshTasks);
           }
           break;
         case 's':
           if (tasks[selectedIdx]) {
-            tasksApi.start(tasks[selectedIdx].id).then(() => qc.invalidateQueries({ queryKey: ['tasks'] }));
+            tasksApi.start(spaceId, tasks[selectedIdx].id).then(refreshTasks);
           }
           break;
         case 'f': case 'F': {
@@ -78,11 +95,12 @@ export function TasksPage() {
     }
     document.addEventListener('keydown', handleKey);
     return () => document.removeEventListener('keydown', handleKey);
-  }, [inputFocused, overlayOpen, tasks, selectedIdx, filter, qc]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inputFocused, overlayOpen, tasks, selectedIdx, filter, qc, spaceId]);
 
   if (isLoading) return <div className="text-[var(--color-text-secondary)]">Loading...</div>;
 
-  const today = new Date().toISOString().slice(0, 10);
+  const today = localToday();
 
   return (
     <div className="space-y-4 max-w-2xl">
@@ -107,13 +125,15 @@ export function TasksPage() {
 
       <InlineForm
         open={showAdd}
+        initialValues={{ priority: 'medium' }}
         fields={[
           { name: 'title', label: 'Title', required: true },
-          { name: 'description', label: 'Description' },
+          { name: 'description', label: 'Description', type: 'textarea' },
+          { name: 'priority', label: 'Priority', type: 'select', options: PRIORITY_OPTIONS },
           { name: 'dueDate', label: 'Due Date', type: 'date' },
         ]}
         onSubmit={(vals) => {
-          createTask.mutate({ title: vals.title, description: vals.description || undefined, dueDate: vals.dueDate || undefined });
+          createTask.mutate({ title: vals.title, description: vals.description || undefined, priority: vals.priority || undefined, dueDate: vals.dueDate || undefined });
           setShowAdd(false);
         }}
         onCancel={() => setShowAdd(false)}
@@ -126,15 +146,17 @@ export function TasksPage() {
           initialValues={{
             title: tasks?.find((t) => t.id === editId)?.title ?? '',
             description: tasks?.find((t) => t.id === editId)?.description ?? '',
+            priority: tasks?.find((t) => t.id === editId)?.priority ?? 'medium',
             dueDate: tasks?.find((t) => t.id === editId)?.dueDate ?? '',
           }}
           fields={[
             { name: 'title', label: 'Title', required: true },
-            { name: 'description', label: 'Description' },
+            { name: 'description', label: 'Description', type: 'textarea' },
+            { name: 'priority', label: 'Priority', type: 'select', options: PRIORITY_OPTIONS },
             { name: 'dueDate', label: 'Due Date', type: 'date' },
           ]}
           onSubmit={(vals) => {
-            updateTask.mutate({ id: editId, title: vals.title, description: vals.description || undefined, dueDate: vals.dueDate || undefined });
+            updateTask.mutate({ id: editId, title: vals.title, description: vals.description || undefined, priority: vals.priority || undefined, dueDate: vals.dueDate || undefined });
             setEditId(null);
           }}
           onCancel={() => setEditId(null)}
@@ -155,13 +177,11 @@ export function TasksPage() {
             >
               <div className="flex items-start gap-3">
                 <button
+                  aria-label={task.status === 'done' ? 'Task done' : 'Mark task done'}
                   onClick={(e) => {
                     e.stopPropagation();
                     if (task.status !== 'done') {
-                      tasksApi.markDone(task.id).then(() => {
-                        qc.invalidateQueries({ queryKey: ['tasks'] });
-                        qc.invalidateQueries({ queryKey: ['status'] });
-                      });
+                      tasksApi.markDone(spaceId, task.id).then(refreshTasks);
                     }
                   }}
                   className={`w-6 h-6 mt-0.5 rounded border-2 flex-shrink-0 flex items-center justify-center text-xs transition-colors ${
@@ -170,7 +190,7 @@ export function TasksPage() {
                       : 'border-[var(--color-border)] hover:border-[var(--color-border-active)]'
                   }`}
                 >
-                  {task.status === 'done' ? '\u2713' : null}
+                  {task.status === 'done' ? '✓' : null}
                 </button>
                 <div className="flex-1 min-w-0">
                   <span className={`text-sm leading-snug ${task.status === 'done' ? 'line-through text-[var(--color-text-secondary)]' : 'text-[var(--color-text-primary)]'}`}>
@@ -185,6 +205,20 @@ export function TasksPage() {
                       </span>
                     )}
                   </div>
+                </div>
+                <div className="flex items-center gap-1 shrink-0">
+                  <button
+                    onClick={(e) => { e.stopPropagation(); setEditId(task.id); }}
+                    className="px-2.5 py-1.5 text-xs rounded border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-accent)] hover:border-[var(--color-border-active)] transition-colors"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={(e) => { e.stopPropagation(); setDeleteId(task.id); }}
+                    className="px-2.5 py-1.5 text-xs rounded border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:text-[var(--color-error)] hover:border-[var(--color-error)] transition-colors"
+                  >
+                    Delete
+                  </button>
                 </div>
               </div>
             </div>

--- a/packages/web/src/themes/themes.ts
+++ b/packages/web/src/themes/themes.ts
@@ -9,7 +9,7 @@ export const neonTheme: Theme = {
     priorityLow: '#4488cc', priorityMed: '#00d4ff', priorityHigh: '#ff6600', priorityUrgent: '#ff3366',
     accent1: '#00d4ff', accent2: '#ff44aa', streakFire: '#ff6600',
     progressFill: '#00d4ff', progressTrack: '#222244',
-    border: '#333366', borderActive: '#00d4ff', tabActive: '#00d4ff', tabInactive: '#444477',
+    border: '#333366', borderActive: '#00d4ff', tabActive: '#00d4ff', tabInactive: '#9a9ad0',
   },
 };
 
@@ -17,12 +17,12 @@ export const matrixTheme: Theme = {
   name: 'matrix',
   colors: {
     bg: '#000000', bgPanel: '#001100', bgHighlight: '#002200',
-    textPrimary: '#00ff00', textSecondary: '#006600', textAccent: '#00ff66',
+    textPrimary: '#00ff00', textSecondary: '#33aa33', textAccent: '#00ff66',
     success: '#00ff00', warning: '#ccff00', error: '#ff0000',
-    priorityLow: '#004400', priorityMed: '#00aa00', priorityHigh: '#ccff00', priorityUrgent: '#ff0000',
+    priorityLow: '#44aa44', priorityMed: '#00aa00', priorityHigh: '#ccff00', priorityUrgent: '#ff0000',
     accent1: '#00ff66', accent2: '#33ff99', streakFire: '#ccff00',
     progressFill: '#00ff00', progressTrack: '#003300',
-    border: '#004400', borderActive: '#00ff66', tabActive: '#00ff66', tabInactive: '#228844',
+    border: '#004400', borderActive: '#00ff66', tabActive: '#00ff66', tabInactive: '#33cc66',
   },
 };
 
@@ -32,10 +32,10 @@ export const purpleTheme: Theme = {
     bg: '#1a0a2e', bgPanel: '#220e3d', bgHighlight: '#2d1550',
     textPrimary: '#e8d5ff', textSecondary: '#9966cc', textAccent: '#cc88ff',
     success: '#66ff99', warning: '#ffcc44', error: '#ff5555',
-    priorityLow: '#7744aa', priorityMed: '#9966cc', priorityHigh: '#ff8844', priorityUrgent: '#ff5555',
+    priorityLow: '#aa77dd', priorityMed: '#9966cc', priorityHigh: '#ff8844', priorityUrgent: '#ff5555',
     accent1: '#cc88ff', accent2: '#ff88cc', streakFire: '#ff8844',
     progressFill: '#cc88ff', progressTrack: '#2d1550',
-    border: '#442266', borderActive: '#cc88ff', tabActive: '#cc88ff', tabInactive: '#7755aa',
+    border: '#442266', borderActive: '#cc88ff', tabActive: '#cc88ff', tabInactive: '#a98ad0',
   },
 };
 
@@ -45,10 +45,10 @@ export const emberTheme: Theme = {
     bg: '#1a0800', bgPanel: '#261200', bgHighlight: '#331a00',
     textPrimary: '#ffe8cc', textSecondary: '#aa7744', textAccent: '#ff8c00',
     success: '#44dd44', warning: '#ffcc00', error: '#ff4444',
-    priorityLow: '#886633', priorityMed: '#cc8833', priorityHigh: '#ff6622', priorityUrgent: '#ff3333',
+    priorityLow: '#bb8844', priorityMed: '#cc8833', priorityHigh: '#ff6622', priorityUrgent: '#ff3333',
     accent1: '#ff8c00', accent2: '#ff4444', streakFire: '#ffaa00',
     progressFill: '#ff8c00', progressTrack: '#331a00',
-    border: '#553311', borderActive: '#ff8c00', tabActive: '#ff8c00', tabInactive: '#886644',
+    border: '#553311', borderActive: '#ff8c00', tabActive: '#ff8c00', tabInactive: '#b89270',
   },
 };
 
@@ -58,10 +58,10 @@ export const frostTheme: Theme = {
     bg: '#0a0e1a', bgPanel: '#0f1526', bgHighlight: '#151d33',
     textPrimary: '#d8e8ff', textSecondary: '#5577aa', textAccent: '#88ccff',
     success: '#55ddaa', warning: '#ffcc55', error: '#ff5566',
-    priorityLow: '#4477aa', priorityMed: '#5599cc', priorityHigh: '#ffaa44', priorityUrgent: '#ff5566',
+    priorityLow: '#6699cc', priorityMed: '#5599cc', priorityHigh: '#ffaa44', priorityUrgent: '#ff5566',
     accent1: '#88ccff', accent2: '#aaddff', streakFire: '#ffaa44',
     progressFill: '#88ccff', progressTrack: '#1a2540',
-    border: '#2a3a55', borderActive: '#88ccff', tabActive: '#88ccff', tabInactive: '#446688',
+    border: '#2a3a55', borderActive: '#88ccff', tabActive: '#88ccff', tabInactive: '#7095bd',
   },
 };
 
@@ -71,10 +71,10 @@ export const sakuraTheme: Theme = {
     bg: '#1a0a10', bgPanel: '#220e18', bgHighlight: '#2d1522',
     textPrimary: '#ffe8ee', textSecondary: '#aa6677', textAccent: '#ff88aa',
     success: '#88dd88', warning: '#ffcc55', error: '#ff4455',
-    priorityLow: '#885566', priorityMed: '#cc7788', priorityHigh: '#ff8855', priorityUrgent: '#ff4455',
+    priorityLow: '#cc8899', priorityMed: '#cc7788', priorityHigh: '#ff8855', priorityUrgent: '#ff4455',
     accent1: '#ff88aa', accent2: '#ffaacc', streakFire: '#ff8855',
     progressFill: '#ff88aa', progressTrack: '#2d1522',
-    border: '#553344', borderActive: '#ff88aa', tabActive: '#ff88aa', tabInactive: '#885566',
+    border: '#553344', borderActive: '#ff88aa', tabActive: '#ff88aa', tabInactive: '#bb8294',
   },
 };
 
@@ -87,7 +87,7 @@ export const auroraTheme: Theme = {
     priorityLow: '#4488aa', priorityMed: '#44bbcc', priorityHigh: '#ff8844', priorityUrgent: '#ff4466',
     accent1: '#44ffaa', accent2: '#aa44ff', streakFire: '#ff8844',
     progressFill: '#44ffaa', progressTrack: '#112233',
-    border: '#334466', borderActive: '#44ffaa', tabActive: '#44ffaa', tabInactive: '#446677',
+    border: '#334466', borderActive: '#44ffaa', tabActive: '#44ffaa', tabInactive: '#7e96b5',
   },
 };
 


### PR DESCRIPTION
## What

Ran the web app locally and audited every page/theme/state with screenshots, then fixed the confirmed bugs (24 distinct issues, deduped from a multi-agent review and each verified against source).

## Highlights

**Critical**
- Task checkbox / `d` / `s`, goal "done", and milestone toggle passed the entity id as the `spaceId` arg → every quick-action 404'd (and it was a real `tsc` error). Now threads `spaceId` and uses correctly-prefixed `invalidateQueries` keys so the UI refreshes.

**High**
- `/api/auth/trial` returned `401` with no session → the client's global "401 → /login" redirect bricked the SPA when OAuth isn't configured. Now returns a `200 {state:'none'}` sentinel (like `/me`); the client also skips the redirect for advisory `/api/auth/*` calls.
- Goals/Tasks/Habits/Areas had **keyboard-only** edit/delete → unusable on touch. Added visible Edit/Delete (and goal Done) controls per row.
- Low-contrast `LOW` priority badge across matrix/purple/sakura/ember/frost themes — brightened the tokens to pass contrast.

**Medium / Low**
- `in_progress` tasks no longer vanish from due/overdue (`ne(status,'done')`).
- Tasks "today" computed in local time, not UTC.
- `InlineForm` gained select/textarea support → task/goal **priority** and habit **frequency/days** are now settable.
- Chat: abort the SSE stream on unmount/new conversation; rewrote the SSE parser to handle multi-line `data:` blocks (was dropping content).
- a11y: global `:focus-visible` ring; stop hijacking bare `Tab`; matrix/`tabInactive` contrast.
- Misc: `html/body` theme background (no white overscroll flash), non-circular `@theme` defaults, dashboard streak-card title truncation, sign-out control, `/admin` route gating + 403 message, milestone space-scoping, and error middleware no longer leaks raw internals on 500.

## Verification
- `pnpm lint` (tsc across all 6 packages): clean.
- `pnpm test`: 183 pass / 46 fail — the 46 failures are **pre-existing** and identical on `main` (the `tests/e2e/*` suite spawns the `plan` CLI via `npx tsx` and gets empty stdout in this environment, plus one timezone-sensitive habit-streak test). No regressions introduced.
- Manually re-verified in the browser: auth no longer bounces to `/login`; task checkbox marks done and refreshes instantly; matrix badges are legible; task/goal/habit forms show the new fields; Edit/Delete render on desktop and mobile; multi-line AI chat streams correctly.

## Notes
- The timezone fix here is the client-side (Tasks page) half. A full fix (server computing "today" in the user's timezone rather than the Fly.io UTC process date) is a larger change left as a follow-up.